### PR TITLE
Tune compressor frequency control logic

### DIFF
--- a/src/openamber.h
+++ b/src/openamber.h
@@ -43,7 +43,7 @@ static const uint32_t WORKING_MODE_COOLING = 1;
 // Working mode heating.
 static const uint32_t WORKING_MODE_HEATING = 2;
 /// Deadband on Tc to avoid too frequent changes around setpoint
-static const float DEAD_BAND_DT = 0.5f;
+static const float DEAD_BAND_DT = 1.0f;
 
 enum class HPState {
     IDLE,
@@ -402,9 +402,9 @@ class OpenAmberController {
   int DetermineSoftStartMode(float supply_temperature_delta) {
     int start_compressor_frequency_mode;
     float delta = fabs(supply_temperature_delta);
-    if (delta < 2.0f) start_compressor_frequency_mode = 1;
-    else if (delta < 5.0f) start_compressor_frequency_mode = 3;
-    else if (delta < 8.0f) start_compressor_frequency_mode = 4;
+    if (delta < 5.0f) start_compressor_frequency_mode = 1;
+    else if (delta < 7.0f) start_compressor_frequency_mode = 3;
+    else if (delta < 10.0f) start_compressor_frequency_mode = 4;
     else start_compressor_frequency_mode = 5;
     return start_compressor_frequency_mode;
   }


### PR DESCRIPTION
This pull request makes adjustments to the control logic for temperature regulation and compressor soft start modes in the `OpenAmberController`. The main focus is on making the system less sensitive to small temperature changes and updating thresholds for compressor frequency modes.

Control logic adjustments:

* Increased the deadband (`DEAD_BAND_DT`) for temperature control from `0.5f` to `1.0f`, making the system less likely to react to small fluctuations around the setpoint.

Compressor soft start logic updates:

* Modified the threshold values in `DetermineSoftStartMode` to require larger temperature deltas before switching to higher compressor frequency modes, reducing the likelihood of starting at a high frequency.