### PR TITLE
Implement settle time after defrosts to pause PID control

### DIFF
--- a/src/openamber.yaml
+++ b/src/openamber.yaml
@@ -964,6 +964,7 @@ binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
     name: "Defrost"
+    id: defrost_active_sensor
     icon: mdi:snowflake
     register_type: holding
     address: 2118


### PR DESCRIPTION
Added new states  `DEFROSTING` and `WAIT_FOR_TEMPERATURE_SETTLE`, allowing the controller to explicitly handle defrost cycles and enforce a settle time after defrost before resuming PID control.