### PR TITLE
Implement safety checks to prevent compressor running while pump is not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,22 @@ Supply temperature regulation with PID-based compressor Hz modulation
 
 ## Features
 - Heating
-- Pump running on customizable interval/duration.
+- Pump running on customizable interval/duration/speed.
 - Compressor modulation based on PID controller.
 - Frost protection in 2 stages (similair to original software).
 - Software thermostat based on Tr sensor.
+- Heat curve(5-points).
+- Backup heater
+- Support external thermostats (Heating/Cooling input)
 
 ## Todo
 - Support cooling
 - Domestic Hot Water/Three way valve control
 - Tv1/Tv2 buffer support
-- Heating curve
-- Backup heater
-- Support external thermostats (Heating/Cooling input)
 - Extend configuration options
   - Enable specific compressor frequencies (silent mode)
 - Error handling
+- Support OpenTherm thermostats
 - .. More
 
 ## Hardware
@@ -93,11 +94,15 @@ Connect wires to your hardware RS485 port (Itho Daalderop Amber Control Module u
 #### Write
 | Address    | Function                                           |
 |:----------:|:--------------------------------------------------:|
-| 1099       | Unknown(pump relay?), needed for initialization    |
-| 1104       | Unknown, needed for initialization                 |
-| 1112       | Three-way valve?                                   |
+| 1099       | Pump P0 relay                                      |
+| 1100       | Pump P1 relay                                      |
+| 1101       | Pump P2 relay                                      |
 | 1103       | Pump P0 state (1000=OFF, 500=LOW, 250=MED, 0=HIGH) |
-| 3999       | Working mode(0=OFF,1=COOL,2=HEAT)                  |
+| 1104       | Unknown, needed for initialization                 |
+| 1105       | 3-way valve DHW                                    |
+| 1109       | Backup heater stage 1 relay                        |
+| 1110       | Backup heater stage 2 relay                        |
+| 1112       | 3-way valve SWW                                    |
 
 ### Outside unit (Address 2)
 #### Read

--- a/src/openamber.yaml
+++ b/src/openamber.yaml
@@ -87,10 +87,9 @@ modbus:
 modbus_controller:
 - id: modbus_outside_unit
   address: 0x2
-  update_interval: 15s
-  command_throttle: 250ms
+  update_interval: 30s
+  command_throttle: 500ms
   max_cmd_retries: 3
-  offline_skip_updates: 10
   on_offline:
     then:
       - lambda: |-
@@ -103,10 +102,9 @@ modbus_controller:
       - logger.log: "Modbus outside unit ONLINE"
 - id: modbus_inside_unit
   address: 0x0B
-  update_interval: 15s
-  command_throttle: 250ms
+  update_interval: 30s
+  command_throttle: 500ms
   max_cmd_retries: 3
-  offline_skip_updates: 10
   on_offline:
     then:
       - lambda: |-
@@ -1313,14 +1311,14 @@ switch:
    on_turn_on: 
      then:
       # Initialize board relays
-      - switch.turn_on: pump_p0_relay
-      - switch.turn_on: pump_p1_relay
-      - switch.turn_on: pump_p2_relay
+      - switch.turn_on: pump_p0_relay_switch
+      - switch.turn_on: pump_p1_relay_switch
+      - switch.turn_on: pump_p2_relay_switch
       - switch.turn_on: initialize_step_4
 
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
-   id: pump_p0_relay
+   id: pump_p0_relay_switch
    name: "Pomp P0 relais"
    address: 1099
    register_type: holding
@@ -1329,7 +1327,7 @@ switch:
      
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
-   id: pump_p1_relay
+   id: pump_p1_relay_switch
    name: "Pomp P1 relais"
    address: 1100
    register_type: holding
@@ -1338,7 +1336,7 @@ switch:
 
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
-   id: pump_p2_relay
+   id: pump_p2_relay_switch
    name: "Pomp P2 relais"
    address: 1101
    register_type: holding


### PR DESCRIPTION
* Added a new `DoSafetyChecks()` method in `OpenAmberController` to ensure the compressor is stopped if the pump is inactive or if the temperature difference between `temp_tuo` and `temp_tui` exceeds 8°C while the compressor is running, preventing potential hardware damage.
* Updated `StartPump()` to explicitly activate the `pump_p0_relay` if it is not already active, increasing robustness during pump start.
* Updated Modbus controller settings to increase `update_interval` and `command_throttle` for both outside and inside units, improving communication stability.