### PR TITLE
Add setting to limit maximum compressor mode

### DIFF
--- a/src/openamber.yaml
+++ b/src/openamber.yaml
@@ -1639,6 +1639,23 @@ switch:
 
 select:
   - platform: template
+    id: heat_compressor_mode
+    name: "Verwarmen vermogen"
+    optimistic: True
+    options:
+      - "Beperkt"
+      - "Zeer laag"
+      - "Laag"
+      - "Gemiddeld"
+      - "Verhoogd"
+      - "Hoog"
+      - "Maximaal"
+    initial_option: "Maximaal"
+    entity_category: config
+    web_server: 
+        sorting_group_id: settings
+
+  - platform: template
     id: heat_mode_select
     name: "Verwarmingsmodus"
     optimistic: True


### PR DESCRIPTION
Allows to limit maximum processor frequency. Can be used to reduce power usage or quiet mode