### PR TITLE
Fixed pump not directly starting when there is compressor demand

### DIFF
--- a/src/openamber.h
+++ b/src/openamber.h
@@ -270,7 +270,7 @@ class OpenAmberController {
         {
             if (!pump_demand) break;
 
-            if (now >= state.next_pump_cycle || compressor_demand)
+            if (now >= state.next_pump_cycle || ShouldStartCompressor(compressor_demand))
             {
                 StartPump();
                 SetNextState(HPState::WAIT_PUMP_RUNNING);

--- a/src/openamber.h
+++ b/src/openamber.h
@@ -270,7 +270,7 @@ class OpenAmberController {
         {
             if (!pump_demand) break;
 
-            if (now >= state.next_pump_cycle)
+            if (now >= state.next_pump_cycle || compressor_demand)
             {
                 StartPump();
                 SetNextState(HPState::WAIT_PUMP_RUNNING);


### PR DESCRIPTION
When the pump cycle would end and there is demand for using the compressor, the pump would wait for the next iteration until it would turn on. Pump will now immediately start when there is demand.