### PR TITLE
Implement support for Domestic Hot Water

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,26 @@ Supply temperature regulation with PID-based compressor Hz modulation
 ![Supply temperature regulation with PID-based compressor Hz modulation](/docs/images/openamber-pid.png)
 
 ## Features
+- Domestic Hot Water/Three way valve control
 - Heating
-- Pump running on customizable interval/duration/speed.
+- Pump P0 full PWM control on customizable interval/duration/speed.
 - Compressor modulation based on PID controller.
+- Configure maximum power modes
 - Frost protection in 2 stages (similair to original software).
 - Software thermostat based on Tr sensor.
 - Heat curve(5-points).
 - Backup heater
+- Boost after defrost using backup heater.
+- Sensors for error codes
 - Support external thermostats (Heating/Cooling input)
 
 ## Todo
 - Support cooling
-- Domestic Hot Water/Three way valve control
 - Tv1/Tv2 buffer support
 - Extend configuration options
-  - Enable specific compressor frequencies (silent mode)
 - Error handling
 - Support OpenTherm thermostats
+- EEPROM updates
 - .. More
 
 ## Hardware
@@ -41,7 +44,6 @@ The firmware in this repository targets this module, I currently use this as wel
 
 #### Waveshare ESP32-S3 Touch LCD 5'' (https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-5)
 This is the best replacement for the WinCE controller as there is a touchscreen, RS485 and 24V input available.
-But I haven't been able to get the RS485 working on my unit so far.
 We would also need a 3D printed bracket to mount it properly.
 
 ## Installation
@@ -97,7 +99,7 @@ Connect wires to your hardware RS485 port (Itho Daalderop Amber Control Module u
 | 1099       | Pump P0 relay                                      |
 | 1100       | Pump P1 relay                                      |
 | 1101       | Pump P2 relay                                      |
-| 1103       | Pump P0 state (1000=OFF, 500=LOW, 250=MED, 0=HIGH) |
+| 1103       | Pump P0 duty cycle (1000=OFF, 0=HIGH)              |
 | 1104       | Unknown, needed for initialization                 |
 | 1105       | 3-way valve DHW                                    |
 | 1109       | Backup heater stage 1 relay                        |
@@ -124,6 +126,8 @@ Connect wires to your hardware RS485 port (Itho Daalderop Amber Control Module u
 | 2117       | High pressure (Pd)                  |
 | 2118       | Defrost active                      |
 | 2119       | Alarm codes (see below)             |
+| 2220       | Alarm codes (see below)             |
+| 2221       | Alarm codes (see below)             |
 | 2122       | Firmware version part 1             |
 | 2123       | EEPROM version                      |
 | 2131       | Temperature?                        |
@@ -133,16 +137,16 @@ Connect wires to your hardware RS485 port (Itho Daalderop Amber Control Module u
 
 #### Write
 | Address    | Function                            |
-|:----------:|:-----------------------------------:|
-| 1999       | Compressor mode(0-10)               |
-| 3999       | Working mode(0=OFF,1=COOL,3=HEAT)   |
+|:----------:|:-----------------------------------------------------------------:|
+| 1999       | Compressor mode(0-10)                                             |
+| 3999       | Working mode(0=OFF,1=COOL,3=HEAT,5=EEPROM UPDATE,6=MAINTENANCE)   |
 
 #### State (Address 2108)
-Not all bits are known, so the ones we know of are listed here.
 
 | Bitmask    | Function                            |
 |:----------:|:-----------------------------------:|
 | 0x01       | Fan low speed mode                  |
+| 0x02       | Compressor crankcase heater         |
 | 0x04       | Bottom heater active                |
 | 0x10       | Fan defrost speed mode              |
 | 0x20       | Fan high speed mode                 |
@@ -150,8 +154,50 @@ Not all bits are known, so the ones we know of are listed here.
 | 0x80       | Expansion valve lock active         |
 
 #### Alarm codes (Address 2119)
-Not all bits are known, so the ones we know of are listed here.
 
-| Bitmask    | Function                            |
-|:----------:|:-----------------------------------:|
-| 0x04       | Oil return cycle (P04)              |
+| Bitmask    | Function |
+|:----------:|:--------:|
+| 0x01       | P01      |
+| 0x02       | P02      |
+| 0x04       | P03      |
+| 0x08       | P04      |
+| 0x10       | P05      |
+| 0x20       | P06      |
+| 0x40       | P07      |
+| 0x80       | P08      |
+| 0x100      | P09      |
+| 0x200      | P10      |
+| 0x400      | P11      |
+| 0x800      | P12      |
+| 0x1000     | P13      |
+
+#### Alarm codes (Address 2220)
+
+| Bitmask    | Function |
+|:----------:|:--------:|
+| 0x01       | F01      |
+| 0x02       | F02      |
+| 0x04       | F03      |
+| 0x08       | F04      |
+| 0x10       | F05      |
+| 0x20       | F06      |
+| 0x40       | F07      |
+| 0x80       | F08      |
+| 0x100      | F09      |
+
+#### Alarm codes (Address 2221)
+
+| Bitmask    | Function |
+|:----------:|:--------:|
+| 0x01       | E01      |
+| 0x02       | E02      |
+| 0x04       | E03      |
+| 0x08       | E04      |
+| 0x10       | E05      |
+| 0x20       | E06      |
+| 0x40       | E07      |
+| 0x80       | E08      |
+| 0x100      | F10      |
+| 0x200      | F16      |
+| 0x400      | F17      |
+| 0x800      | F18      |

--- a/src/openamber.h
+++ b/src/openamber.h
@@ -884,7 +884,7 @@ class OpenAmberController {
   void SetPumpPwmDutyCycle(float duty_cycle)
   {
     float control_speed = ((duty_cycle*10)*-1)+1000;
-    if(this->pump_p0_current_pwm->state != control_speed)
+    if(this->pump_p0_current_pwm->raw_state != control_speed)
     {
       ESP_LOGI("amber", "Applying pump speed change to %.0f (Duty cycle: %.0f)", control_speed, duty_cycle);
       auto pump_call = this->pump_control->make_call();

--- a/src/openamber.h
+++ b/src/openamber.h
@@ -50,6 +50,8 @@ static const uint32_t COMPRESSOR_SETTLE_TIME_AFTER_DEFROST_S = 5 * 60;
 static const uint32_t BACKUP_HEATER_LOOKAHEAD_S = 2 * 60;
 // Settle time after backup heater is turned off before compressor PID loop starts again.
 static const uint32_t BACKUP_HEATER_OFF_SETTLE_TIME_S = 2 * 60;
+// Time required to switch the 3-way valve position.
+static const uint32_t THREE_WAY_VALVE_SWITCH_TIME_S = 1 * 60;
 
 enum class HPState {
     UNKNOWN,
@@ -58,13 +60,20 @@ enum class HPState {
     WAIT_PUMP_STOP,
     PUMP_INTERVAL_RUNNING,
     WAIT_COMPRESSOR_RUNNING,
-    COMPRESSOR_SOFTSTART,
+    HEAT_COOL_COMPRESSOR_SOFTSTART,
     COMPRESSOR_RUNNING,
     WAIT_BACKUP_HEATER_RUNNING,
     BACKUP_HEATER_RUNNING,
     DEFROSTING,
-    WAIT_COMPRESSOR_STOP,
     WAIT_FOR_STATE_SWITCH,
+    SWITCH_TO_DHW,
+    WAIT_COMPRESSOR_STOP,
+    WAIT_3WAY_VALVE_SWITCH,
+};
+
+enum ThreeWayValvePosition {
+    HEATING_COOLING,
+    DHW,
 };
 
 struct AmberState {
@@ -78,12 +87,13 @@ struct AmberState {
   // Backup heater degree / minute tracking.
   uint32_t backup_degmin_last_ms = 0;
   float accumulated_backup_degmin = 0.0;
-  float tc_rate_c_per_min = 0.0;
-  float last_tc_for_rate = 0.0;
+  float temperature_rate_c_per_min = 0.0;
+  float last_temperature_for_rate = 0.0;
 
   HPState hp_state = HPState::IDLE;
   HPState deferred_hp_state = HPState::UNKNOWN;
   uint32_t defer_state_change_until_ms = 0;
+  bool is_switching_modes = false;
 };
 
 class OpenAmberController {
@@ -96,10 +106,11 @@ class OpenAmberController {
   sensor::Sensor *temp_tuo = nullptr;
   sensor::Sensor *temp_outside = nullptr;
   sensor::Sensor *room_temp = nullptr;
+  sensor::Sensor *dhw_temperature_tw = nullptr;
   number::Number *pump_interval_min = nullptr;
   number::Number *pump_duration_min = nullptr;
   sensor::Sensor *compressor_current_frequency = nullptr;
-  pid::PIDClimate *pid_climate = nullptr;
+  pid::PIDClimate *pid_heat_cool = nullptr;
   climate::Climate *thermostat_climate = nullptr;
   number::Number *pump_control = nullptr;
   binary_sensor::BinarySensor *pump_active = nullptr;
@@ -110,6 +121,7 @@ class OpenAmberController {
   text_sensor::TextSensor *hp_state_text_sensor = nullptr;
   binary_sensor::BinarySensor *oil_return_cycle = nullptr;
   number::Number *pump_speed_heating = nullptr;
+  number::Number *pump_speed_dhw = nullptr;
   binary_sensor::BinarySensor *heat_demand = nullptr;
   binary_sensor::BinarySensor *cool_demand = nullptr;
   binary_sensor::BinarySensor *defrost_active = nullptr;
@@ -121,7 +133,19 @@ class OpenAmberController {
   select::Select *heat_compressor_max_mode = nullptr;
   sensor::Sensor *pump_p0_current_pwm = nullptr;
   number::Number *defrost_backup_heater_boost_temperature = nullptr;
+
+  select::Select *three_way_valve_position = nullptr;
+  switch_::Switch *three_way_valve_dhw = nullptr;
+  number::Number *dhw_setpoint = nullptr;
+  binary_sensor::BinarySensor *dhw_demand = nullptr;
+  select::Select *dhw_compressor = nullptr;
+  select::Select *dhw_compressor_max = nullptr;
+  number::Number *dhw_ta_temperature_compressor_max = nullptr;
+  switch_::Switch *dhw_enabled = nullptr;
+  switch_::Switch *dhw_pump = nullptr;  
   int mode_offset = 0;
+  int dhw_mode_offset = 0;
+  int dhw_mode_max_offset = 0;
 
   void loop() {
     if(this->initialized)
@@ -136,7 +160,7 @@ class OpenAmberController {
     }
   }
 
-  void WritePIDValue(float pid_value) {
+  void WriteHeatPIDValue(float pid_value) {
     ESP_LOGD("amber", "Writing PID value: %.2f", pid_value);
     state.compressor_pid = pid_value;
   }
@@ -164,13 +188,15 @@ class OpenAmberController {
     this->pump_duration_min = &id(pump_duration);
 
     this->compressor_current_frequency = &id(current_compressor_frequency);
-    this->pid_climate = &id(compressor_pid_climate);
+    this->pid_heat_cool = &id(pid_heat_cool_temperature_control);
+    this->dhw_temperature_tw = &id(dhw_temperature_tw_sensor);
     this->thermostat_climate = &id(climate_controller);
     this->heat_demand = &id(heat_demand_active_sensor);
     this->cool_demand = &id(cool_demand_active_sensor);
 
     this->pump_control = &id(pump_control_pwm_number);
     this->pump_speed_heating = &id(pump_speed_heating_number);
+    this->pump_speed_dhw = &id(pump_speed_dhw_number);
     this->pump_active = &id(internal_pump_active);
     this->frost_protection_stage1 = &id(frost_protection_stage1_active);
     this->frost_protection_stage2 = &id(frost_protection_stage2_active);
@@ -192,7 +218,21 @@ class OpenAmberController {
 
     this->defrost_backup_heater_boost_temperature = &id(defrost_backup_heater_boost_temperature_sensor);
 
+    this->three_way_valve_position = &id(three_way_valve_select);
+    this->dhw_demand = &id(dhw_demand_active_sensor);
+    this->dhw_setpoint = &id(dhw_setpoint_temperature);
+    this->dhw_compressor = &id(dhw_compressor_mode);
+    this->dhw_compressor_max = &id(dhw_compressor_mode_max);
+    this->dhw_ta_temperature_compressor_max = &id(dhw_temperature_threshold_max_compressor_mode);
+    this->dhw_enabled = &id(dhw_enabled_switch);
+    this->dhw_pump = &id(dhw_pump_relay_switch);
+    this->three_way_valve_dhw = &id(three_way_valve_dhw_switch);
+
     this->mode_offset = this->compressor_control->size() - this->heat_compressor_max_mode->size();
+
+    // Restore 3-way valve state based on relay position.
+    bool is_valve_in_dhw_position = this->three_way_valve_dhw->state;
+    SetThreeWayValve(is_valve_in_dhw_position ? ThreeWayValvePosition::DHW : ThreeWayValvePosition::HEATING_COOLING);
 
     // Restore state whenever initialized while compressor is running.
     if(this->compressor_current_frequency->state > 0) {
@@ -203,6 +243,10 @@ class OpenAmberController {
     {
       state.pump_start_time = millis();
       SetNextState(HPState::PUMP_INTERVAL_RUNNING);
+    }
+    else if (this->backup_heater_active->state)
+    {
+      SetNextState(HPState::BACKUP_HEATER_RUNNING);
     }
     else
     {
@@ -239,21 +283,23 @@ class OpenAmberController {
   {
       const uint32_t now = millis();
 
-      float tc = temp_tc->state;
-      float target_temperature = pid_climate->target_temperature;
-      float supply_temperature_delta = tc - target_temperature;
+       // TODO: This probably needs more logic around priorities and heating time on or post defrost.
+      bool dhw_demand = this->dhw_demand->state && this->dhw_enabled->state;
+
+      float current_temperature = GetCurrentTemperature();
+      float target_temperature = GetTargetTemperature();
+      float supply_temperature_delta = GetTemperatureDelta();
 
       bool frost_protection_stage2_active = frost_protection_stage2->state;
       bool frost_protection_stage1_active = frost_protection_stage1->state;
 
       bool heating_or_cooling_demand = heat_demand->state || cool_demand->state;
 
-      bool pump_demand = heating_or_cooling_demand || frost_protection_stage1_active || frost_protection_stage2_active;
-      bool compressor_demand = heating_or_cooling_demand || frost_protection_stage2_active;
+      bool pump_demand = dhw_demand || heating_or_cooling_demand || frost_protection_stage1_active || frost_protection_stage2_active;
       bool pump_running = pump_active->state;
       bool compressor_running = compressor_current_frequency->state > 0;
 
-      const uint32_t min_on_ms  = COMPRESSOR_MIN_ON_S  * 1000UL;
+      const uint32_t min_on_ms = COMPRESSOR_MIN_ON_S  * 1000UL;
 
       switch (state.hp_state)
       {
@@ -265,7 +311,7 @@ class OpenAmberController {
             break;
           }
           else
-          {     
+          {
             state.defer_state_change_until_ms = 0;
             SetNextState(state.deferred_hp_state);
             state.deferred_hp_state = HPState::UNKNOWN;
@@ -276,6 +322,21 @@ class OpenAmberController {
         {
             if (!pump_demand) break;
 
+            if (dhw_demand && !IsThreeWayValveInPosition(ThreeWayValvePosition::DHW))
+            {
+              SetThreeWayValve(ThreeWayValvePosition::DHW);
+              state.is_switching_modes = true;
+              LeaveStateAndSetNextStateAfterWaitTime(HPState::IDLE, THREE_WAY_VALVE_SWITCH_TIME_S * 1000UL);
+              break;
+            }
+            else if (!dhw_demand && !IsThreeWayValveInPosition(ThreeWayValvePosition::HEATING_COOLING))
+            {
+              state.is_switching_modes = true;
+              LeaveStateAndSetNextStateAfterWaitTime(HPState::IDLE, THREE_WAY_VALVE_SWITCH_TIME_S * 1000UL);
+              break;   
+            }
+
+            // If interval is elapsed or there is compressor demand, start pump immediately.
             if (now >= state.next_pump_cycle || ShouldStartCompressor(compressor_demand))
             {
                 StartPump();
@@ -294,7 +355,7 @@ class OpenAmberController {
         }
         case HPState::PUMP_INTERVAL_RUNNING:
         {
-          bool should_start_compressor = ShouldStartCompressor(compressor_demand);
+          bool should_start_compressor = ShouldStartCompressor();
           ApplyPumpSpeedChangeIfNeeded();
 
           // Stop pump when duration expired.
@@ -313,14 +374,41 @@ class OpenAmberController {
           }
 
           bool pump_on_long_enough = millis() - state.pump_start_time >= (COMPRESSOR_MIN_TIME_PUMP_ON * 1000UL);
-          if(!pump_on_long_enough) {
+          if(!pump_on_long_enough && !IsInDhwMode()) {
             ESP_LOGI("amber", "Not starting compressor because Tc needs to stabilize (pump on time too short)");
             break;
           }
 
-          SetWorkingMode(this->heat_demand->state ? WORKING_MODE_HEATING : WORKING_MODE_COOLING);
-          StartCompressor(supply_temperature_delta);
+          // After mode switch, always start when there is demand.
+          const uint32_t min_off_ms = COMPRESSOR_MIN_OFF_S * 1000UL;
+          if (millis() < state.last_compressor_stop_ms + min_off_ms && !state.is_switching_modes) {
+            ESP_LOGI("amber", "Not starting compressor because minimum compressor time off is not reached.");
+            return false;
+          }
+
+          int workingMode = IsInDhwMode() ? WORKING_MODE_HEATING :
+                            this->heat_demand->state ? WORKING_MODE_HEATING : WORKING_MODE_COOLING;
+
+          SetWorkingMode(workingMode);
+          StartCompressor();
           SetNextState(HPState::WAIT_COMPRESSOR_RUNNING);
+          break;
+        }
+        case HPState::WAIT_PUMP_STOP:
+        {
+          if (!pump_running)
+          {
+            if(IsInDhwMode())
+            {
+              // If we are in DHW mode, always switch back to heating/cooling after pump is stopped.
+              SetThreeWayValve(ThreeWayValvePosition::HEATING_COOLING);
+            }
+
+            SetNextState(HPState::IDLE);
+          }
+          else {
+            // TODO: Implement timeout for when pump does not stop.
+          }
           break;
         }
         case HPState::WAIT_COMPRESSOR_RUNNING:
@@ -328,12 +416,12 @@ class OpenAmberController {
           if (compressor_running)
           {
             state.last_compressor_start_ms = now;
-            SetNextState(HPState::COMPRESSOR_SOFTSTART);
+            SetNextState(IsInDhwMode() ? HPState::COMPRESSOR_RUNNING : HPState::HEAT_COOL_COMPRESSOR_SOFTSTART);
           }
           // TODO: Implement timeout for when compressor does not start.
           break;
         }
-        case HPState::COMPRESSOR_SOFTSTART:
+        case HPState::HEAT_COOL_COMPRESSOR_SOFTSTART:
         {
           if (now - state.last_compressor_start_ms >= COMPRESSOR_SOFT_START_DURATION_S * 1000UL)
           {
@@ -366,15 +454,23 @@ class OpenAmberController {
           // Only check for stop conditions when min on time is passed.
           if (hasPassedMinOnTime)
           {
-            if (!compressor_demand) {
+            if (!IsCompressorDemandForCurrentMode()) {
               ESP_LOGI("amber", "Stopping compressor because there is no demand.");
               StopCompressor();
               SetNextState(HPState::WAIT_COMPRESSOR_STOP);
               break;
             }
 
-            // Stop when we are close enough to target
-            if (supply_temperature_delta >= stop_compressor_delta->state) {
+            if (dhw_demand && !IsInDhwMode())
+            {
+                ESP_LOGI("amber", "Stopping compressor because there is demand for DHW.");
+                StopCompressor();
+                SetNextState(HPState::WAIT_COMPRESSOR_STOP);
+                break;
+            }
+
+            // Stop when we overshoot above target + delta.
+            if (supply_temperature_delta >= stop_compressor_delta->state && !IsInDhwMode()) {
               if(this->oil_return_cycle->state)
               {
                 // Every 2 hours of compressor running in low frequency it will do an oil return cycle, this will mess up the delta T based stopping.
@@ -390,7 +486,14 @@ class OpenAmberController {
             }
           }
 
-          ManageCompressorModulation();
+          if(IsInDhwMode())
+          {
+            // TODO: Implement go to max configured frequency when Ta is below specified setting.
+          }
+          else 
+          {
+            ManageCompressorModulation();
+          }
           break;
         }
         case HPState::WAIT_COMPRESSOR_STOP:
@@ -415,10 +518,10 @@ class OpenAmberController {
         }
         case HPState::BACKUP_HEATER_RUNNING:
         {
-          float predicted_tc = CalculateBackupHeaterPredictedTc();
-          // Disable backup heater if predicted Tc is above target.
-          if(predicted_tc >= target_temperature + 2.0f) { // Margin to buffer some heat to reduce undershoot.
-            ESP_LOGI("amber", "Disabling backup heater (predicted Tc %.2f°C above target %.2f°C)", predicted_tc, target_temperature);
+          float predicted_temperature = CalculateBackupHeaterPredictedTemperature();
+          // Disable backup heater if predicted Temperature is above target.
+          if(predicted_temperature >= target_temperature + 2.0f) { // Margin to buffer some heat to reduce undershoot.
+            ESP_LOGI("amber", "Disabling backup heater (predicted Temperature %.2f°C above target %.2f°C)", predicted_temperature, target_temperature);
             backup_heater->turn_off();
             LeaveStateAndSetNextStateAfterWaitTime(HPState::COMPRESSOR_RUNNING, BACKUP_HEATER_OFF_SETTLE_TIME_S * 1000UL);
             return;
@@ -451,6 +554,29 @@ class OpenAmberController {
       }
   }
 
+  bool IsInDhwMode()
+  {
+    return IsThreeWayValveInPosition(ThreeWayValvePosition::DHW);
+  }
+
+  bool IsThreeWayValveInPosition(ThreeWayValvePosition position)
+  {
+    return this->three_way_valve_position->active_index() == (int)position;
+  }
+
+  void SetThreeWayValve(ThreeWayValvePosition position)
+  {
+      auto three_way_valve_call = this->three_way_valve_position->make_call();
+      three_way_valve_call.set_index((int)position);
+      three_way_valve_call.perform();
+      ESP_LOGI("amber", "Setting 3-way valve to %s.", this->three_way_valve_position->current_option());
+  }
+
+  select::Select *GetCurrentPumpSpeedSettingSelect()
+  {
+    return IsInDhwMode() ? this->pump_speed_dhw : this->pump_speed_heating;
+  }
+
   void ApplyPumpSpeedChangeIfNeeded()
   {
     if(!this->pump_active->state)
@@ -461,10 +587,12 @@ class OpenAmberController {
     SetPumpPwmDutyCycle(this->pump_speed_heating->state);
   }
 
+  /// @brief Calculate and update the accumulated backup heater degree/minutes.
+  /// Will not accumulate if not at max compressor mode.
   void CalculateAccumulatedBackupHeaterDegreeMinutes()
   {
     float tc = temp_tc->state;
-    float target = pid_climate->target_temperature;
+    float target = pid_heat_cool->target_temperature;
     const float diff = std::max(0.0f, target - tc);
     uint32_t dt_ms = millis() - state.backup_degmin_last_ms;
     state.backup_degmin_last_ms = millis();
@@ -488,10 +616,10 @@ class OpenAmberController {
     ESP_LOGD("amber", "Backup heater degree/minutes updated: +%.2f -> %.2f", diff * dt_min, state.accumulated_backup_degmin);
   }
 
-  float CalculateBackupHeaterPredictedTc()
+  float CalculateBackupHeaterPredictedTemperature()
   {
-    float tc = temp_tc->state;
-    float target = pid_climate->target_temperature;
+    float current_temperature = GetCurrentTemperature();
+    float target = GetTargetTemperature();
 
     uint32_t dt_ms = millis() - state.backup_degmin_last_ms;
     const float dt_min = (float)dt_ms / 60000.0f;
@@ -501,38 +629,37 @@ class OpenAmberController {
       return 0.0f;
     }
     // Calculate degree/minute rate.
-    float rate = (tc - state.last_tc_for_rate) / dt_min;
+    float rate = (current_temperature - state.last_temperature_for_rate) / dt_min;
     // Low-pass filter the rate to avoid spikes.
     double a = 0.2f;
-    state.tc_rate_c_per_min = (1-a) * state.tc_rate_c_per_min + a * rate;
-    state.last_tc_for_rate = tc;
-
+    state.temperature_rate_c_per_min = (1-a) * state.temperature_rate_c_per_min + a * rate;
+    state.last_temperature_for_rate = current_temperature;
     // Predict future Tc based on current rate.
-    float predicted_tc = tc + state.tc_rate_c_per_min * ((float)BACKUP_HEATER_LOOKAHEAD_S / 60.0f);
+    float predicted_temperature = current_temperature + state.temperature_rate_c_per_min * ((float)BACKUP_HEATER_LOOKAHEAD_S / 60.0f);
     state.backup_degmin_last_ms = millis();
-    ESP_LOGI("amber", "Backup heater tc rate/min updated: %.2f (Predicted Tc: %.2fÂ°C)", state.tc_rate_c_per_min, predicted_tc);
-    return predicted_tc;
+    ESP_LOGI("amber", "Backup heater temperature rate/min updated: %.2f (Predicted Temperature: %.2fÂ°C)", state.temperature_rate_c_per_min, predicted_temperature);
+    return predicted_temperature;
   }
 
-  bool ShouldStartCompressor(bool compressor_demand)
+  bool ShouldStartCompressor()
   {
-    float tc = temp_tc->state;
-    const uint32_t min_off_ms = COMPRESSOR_MIN_OFF_S * 1000UL;
+    if(IsInDhwMode())
+    {
+      return this->dhw_demand->state;
+    }
+
+    float current_temperature = GetCurrentTemperature();
+    float target_temperature = GetTargetTemperature();
   
-    if (!compressor_demand) {
+    if (!IsCompressorDemandForCurrentMode()) {
       ESP_LOGI("amber", "Not starting compressor because there is no demand.");
       return false;
     }
 
-    // Start condition based on Tc and start_compressor_delta.
-    float start_temperature = pid_climate->target_temperature - start_compressor_delta->state;
-    if (tc >= start_temperature && !frost_protection_stage2->state) {
-      ESP_LOGI("amber", "Not starting compressor because Tc(%.2f) is higher than the start temperature(%.2f)", tc, start_temperature);
-      return false;
-    }
-
-    if (millis() < state.last_compressor_stop_ms + min_off_ms) {
-      ESP_LOGI("amber", "Not starting compressor because minimum compressor time off is not reached.");
+    // Start condition based on target temperature and start_compressor_delta.
+    float start_temperature = target_temperature - start_compressor_delta->state;
+    if (current_temperature >= start_temperature && !frost_protection_stage2->state) {
+      ESP_LOGI("amber", "Not starting compressor because target temperature (%.2f) is higher than the start temperature(%.2f)", current_temperature, start_temperature);
       return false;
     }
 
@@ -550,9 +677,9 @@ class OpenAmberController {
     }
 
     // Deadband on Tc to avoid too frequent changes around setpoint
-    float tc = temp_tc->state;
-    float target = pid_climate->target_temperature;
-    float dt = tc - target;
+    float current_temperature = GetCurrentTemperature();
+    float target = GetTargetTemperature();
+    float dt = GetTemperatureDelta();
 
     if (fabsf(dt) < DEAD_BAND_DT) {
       ESP_LOGD("amber", "ΔT=%.2f°C within deadband, compressor mode remains at %d",
@@ -562,8 +689,8 @@ class OpenAmberController {
 
     // If Tc is above setpoint, then never modulate up.
     const float TEMP_MARGIN = 0.3f; // Minor margin to reduce noise
-    if (tc > (target + TEMP_MARGIN) && desired_compressor_mode > current_compressor_mode) {
-        ESP_LOGW("amber", "Tc is above target and PID controller wanted to move to a higher compressor mode.");
+    if (current_temperature > (target + TEMP_MARGIN) && desired_compressor_mode > current_compressor_mode) {
+        ESP_LOGW("amber", "Temperature is above target and PID controller wanted to move to a higher compressor mode.");
         return;
     }
     
@@ -602,6 +729,39 @@ class OpenAmberController {
 
     pid_climate->reset_integral_term();
     SetCompressorMode(compressor_frequency_mode);
+    SetWorkingMode(WORKING_MODE_STANDBY);
+
+    if (run_pump_interval)
+    {
+      // Let pump run for another 60 seconds.
+      state.next_pump_cycle = millis() + (uint32_t)pump_interval_min->state * 60000UL;
+    }
+  }
+
+  void StartCompressor() {
+    state.is_switching_modes = false;
+    if(IsInDhwMode())
+    { 
+      float temperature_ta = temp_outside->state;
+      float ta_threshold = dhw_ta_temperature_compressor_max->state;
+      int dhw_compressor_mode = this->dhw_compressor->active_index().value() + this->dhw_mode_offset;
+      if(temperature_ta <= ta_threshold)
+      {
+          dhw_compressor_mode = this->dhw_compressor_max->active_index().value() + this->dhw_mode_max_offset;
+          ESP_LOGI("amber", "Outside temperature (Ta=%.2f°C) is below threshold (%.2f°C), setting DHW compressor to max mode", temperature_ta, ta_threshold);
+      }
+      ESP_LOGI("amber", "Starting compressor in DHW mode, setting compressor to mode %d", dhw_compressor_mode);
+      SetCompressorMode(dhw_compressor_mode);
+    }
+    else
+    {
+      float supply_temperature_delta = GetTemperatureDelta();
+      ESP_LOGI("amber", "Starting compressor (ΔT=%.2f°C)", supply_temperature_delta);
+      int compressor_frequency_mode = DetermineSoftStartMode(supply_temperature_delta);
+      ESP_LOGI("amber", "Soft start mode: %d (ΔT=%.1f°C)", compressor_frequency_mode, supply_temperature_delta);
+      pid_heat_cool->reset_integral_term();
+      SetCompressorMode(compressor_frequency_mode);
+    }
   }
 
   /// @brief Determine the compressor mode at which to start the compressor.
@@ -654,12 +814,23 @@ class OpenAmberController {
       this->pump_p0_relay->turn_on();
     }
 
-    SetPumpPwmDutyCycle(this->pump_speed_heating->state);
+    SetPumpPwmDutyCycle(GetCurrentPumpSpeedSettingSelect());
+
+    if(IsInDhwMode()) {
+      ESP_LOGI("amber", "Starting DHW pump.");
+      this->dhw_pump->turn_on();
+    }
+
     state.pump_start_time = millis();
   }
 
   void StopPump()
   {
+    if(IsInDhwMode()) {
+      ESP_LOGI("amber", "Starting DHW pump.");
+      this->dhw_pump->turn_off();
+    }
+
     SetPumpPwmDutyCycle(0);
   }
 
@@ -668,6 +839,35 @@ class OpenAmberController {
     auto working_mode_call = working_mode->make_call();
     working_mode_call.set_index(workingMode);
     working_mode_call.perform();
+  }
+
+  float GetTargetTemperature()
+  {
+    bool is_dhw_mode = IsThreeWayValveInPosition(ThreeWayValvePosition::DHW);
+    return is_dhw_mode ? this->dhw_setpoint->state : this->pid_heat_cool->target_temperature;
+  }
+
+  float GetCurrentTemperature()
+  {
+    bool is_dhw_mode = IsThreeWayValveInPosition(ThreeWayValvePosition::DHW);
+    return is_dhw_mode ? this->dhw_temperature_tw->state : this->temp_tc->state;
+  }
+
+  float GetTemperatureDelta()
+  {
+    return GetCurrentTemperature() - GetTargetTemperature();
+  }
+
+  bool IsCompressorDemandForCurrentMode()
+  {
+    if(IsInDhwMode())
+    {
+        return this->dhw_demand->state;
+    }
+    else
+    {
+        return this->heat_demand->state || this->cool_demand->state || frost_protection_stage2->state;
+    }
   }
 
   void LeaveStateAndSetNextStateAfterWaitTime(HPState new_state, uint32_t defer_ms)
@@ -680,56 +880,58 @@ class OpenAmberController {
   void SetPumpPwmDutyCycle(float duty_cycle)
   {
     float control_speed = ((duty_cycle*10)*-1)+1000;
-    ESP_LOGI("amber", "Applying pump speed change to %.0f (Duty cycle: %.0f)", control_speed, duty_cycle);
-
     if(this->pump_p0_current_pwm->state != control_speed)
     {
-      this->pump_control->publish_state(control_speed);
+      ESP_LOGI("amber", "Applying pump speed change to %.0f (Duty cycle: %.0f)", control_speed, duty_cycle);
+      auto pump_call = this->pump_control->make_call();
+      pump_call.set_value(control_speed);
+      pump_call.perform();
     }
   }
 
   void SetNextState(HPState new_state)
   {
-      const char *txt = "Unknown";
-      state.hp_state = new_state;
-      switch (new_state) {
-        case HPState::IDLE:
-          txt = "Idle";
-          break;
-        case HPState::PUMP_INTERVAL_RUNNING:
-          txt = "Pump interval running";
-          break;
-        case HPState::WAIT_PUMP_RUNNING:
-          txt = "Wait for pump running";
-          break;
-        case HPState::WAIT_COMPRESSOR_RUNNING:
-          txt = "Wait for compressor running";
-          break;
-        case HPState::COMPRESSOR_SOFTSTART:
-          txt = "Compressor soft start";
-          break;
-        case HPState::COMPRESSOR_RUNNING:
-          txt = "Compressor running";
-          break;
-        case HPState::WAIT_COMPRESSOR_STOP:
-          txt = "Waiting for compressor to stop";
-          break;
-        case HPState::WAIT_BACKUP_HEATER_RUNNING:
-          txt = "Wait for backup heater running";
-          break;
-        case HPState::BACKUP_HEATER_RUNNING:
-          txt = "Backup heater running";
-          break;
-        case HPState::DEFROSTING:
-          txt = "Defrosting";
-          break;
-        case HPState::WAIT_FOR_STATE_SWITCH:
-          txt = "Waiting for wait time to elapse";
-          break;
-        case HPState::WAIT_PUMP_STOP:
-          txt = "Waiting for pump to stop";
-          break;
-      }
+    const char *txt = "Unknown";
+    state.hp_state = new_state;
+
+    switch (new_state) {
+      case HPState::IDLE:
+        txt = "Idle";
+        break;
+      case HPState::PUMP_INTERVAL_RUNNING:
+        txt = "Pump interval running";
+        break;
+      case HPState::WAIT_PUMP_RUNNING:
+        txt = "Wait for pump running";
+        break;
+      case HPState::WAIT_COMPRESSOR_RUNNING:
+        txt = "Wait for compressor running";
+        break;
+      case HPState::HEAT_COOL_COMPRESSOR_SOFTSTART:
+        txt = "Compressor soft start";
+        break;
+      case HPState::COMPRESSOR_RUNNING:
+        txt = "Compressor running";
+        break;
+      case HPState::WAIT_COMPRESSOR_STOP:
+        txt = "Waiting for compressor to stop";
+        break;
+      case HPState::WAIT_BACKUP_HEATER_RUNNING:
+        txt = "Wait for backup heater running";
+        break;
+      case HPState::BACKUP_HEATER_RUNNING:
+        txt = "Backup heater running";
+        break;
+      case HPState::DEFROSTING:
+        txt = "Defrosting";
+        break;
+      case HPState::WAIT_FOR_STATE_SWITCH:
+        txt = "Waiting for wait time to elapse";
+        break;
+      case HPState::WAIT_PUMP_STOP:
+        txt = "Waiting for pump to stop";
+        break;
+    }
 
     hp_state_text_sensor->publish_state(txt);
     ESP_LOGI("amber", "HP state changed: %s", txt);

--- a/src/openamber.h
+++ b/src/openamber.h
@@ -235,8 +235,15 @@ class OpenAmberController {
     this->pump_p0_relay->turn_on();
 
     // Restore 3-way valve state based on relay position.
-    bool is_valve_in_dhw_position = this->three_way_valve_dhw->state;
-    SetThreeWayValve(is_valve_in_dhw_position ? ThreeWayValvePosition::DHW : ThreeWayValvePosition::HEATING_COOLING);
+    if (this->dhw_enabled->state)
+    {
+      bool is_valve_in_dhw_position = this->three_way_valve_dhw->state;
+      SetThreeWayValve(is_valve_in_dhw_position ? ThreeWayValvePosition::DHW : ThreeWayValvePosition::HEATING_COOLING);
+    }
+    else 
+    {
+      SetThreeWayValve(ThreeWayValvePosition::HEATING_COOLING);
+    }
 
     // Restore state whenever initialized while compressor is running.
     if(this->compressor_current_frequency->state > 0) {

--- a/src/openamber.yaml
+++ b/src/openamber.yaml
@@ -155,9 +155,8 @@ climate:
 
   # TODO: Find a way to set PID values from settings and maybe different profiles for heating/cooling/dhw.
   - platform: pid
-    id: compressor_pid_climate
+    id: pid_heat_cool_temperature_control
     internal: True
-    name: "Compressor PID Climate"
     sensor: heat_cool_temperature_tc
     default_target_temperature: 30°C
     heat_output: pid_heat_output
@@ -180,7 +179,7 @@ output:
     type: float
     write_action:
       - lambda: |-
-          AMBER.WritePIDValue(state);
+          AMBER.WriteHeatPIDValue(state);
 
   - platform: template
     id: pid_cool_output
@@ -263,7 +262,7 @@ sensor:
     }
   on_value:
     - lambda: |-
-        auto call = id(compressor_pid_climate).make_call();
+        auto call = id(pid_heat_cool_temperature_control).make_call();
         call.set_target_temperature(x);
         call.perform();
 
@@ -323,6 +322,7 @@ sensor:
 
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
+  id: dhw_temperature_tw_sensor
   name: "Tapwatertemperatuur (Tw)"
   address: 1200
   register_type: holding
@@ -755,6 +755,17 @@ text_sensor:
 
 binary_sensor:
   - platform: template
+    name: "Tapwater vraag"
+    id: dhw_demand_active_sensor
+    device_class: running
+    lambda: |-
+        float restart_delta = id(dhw_restart_dhw_delta).state;
+        float tw = id(dhw_temperature_tw_sensor).state;
+        float setpoint = id(dhw_setpoint_temperature).state;
+
+        return (setpoint - tw) >= restart_delta;
+
+  - platform: template
     name: "Warmtevraag"
     id: heat_demand_active_sensor
     device_class: running
@@ -863,6 +874,7 @@ binary_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: modbus_inside_unit
+    id: dhw_pump_active_sensor
     name: "Tapwater pomp"
     address: 1302
     register_type: holding
@@ -974,6 +986,7 @@ binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
     name: "Bedrijfstroom warmtepomp (P01)"
+    name: "Bedrijfstroom warmtepomp (P01)"
     register_type: holding
     address: 2119
     bitmask: 0x0001
@@ -1002,6 +1015,7 @@ binary_sensor:
     modbus_controller_id: modbus_outside_unit
     id: oil_return_cycle_active
     name: "Olie-terugloopcyclus (P04)"
+    name: "Olie-terugloopcyclus (P04)"
     icon: mdi:autorenew
     register_type: holding
     address: 2119
@@ -1012,6 +1026,7 @@ binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
     name: "Hogedrukbeveiliging (P05)"
+    name: "Hogedrukbeveiliging (P05)"
     register_type: holding
     address: 2119
     bitmask: 0x0010
@@ -1020,6 +1035,7 @@ binary_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
+    name: "Laag drukverschil (P06)"
     name: "Laag drukverschil (P06)"
     register_type: holding
     address: 2119
@@ -1030,6 +1046,7 @@ binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
     name: "Compressor voorverwarming (P07)"
+    name: "Compressor voorverwarming (P07)"
     register_type: holding
     address: 2119
     bitmask: 0x0040
@@ -1038,6 +1055,7 @@ binary_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
+    name: "Storing sensor persgasdruk (P08)"
     name: "Storing sensor persgasdruk (P08)"
     register_type: holding
     address: 2119
@@ -1086,6 +1104,47 @@ binary_sensor:
     name: "Laag drukverschil (P13)"
     register_type: holding
     address: 2119
+    value_type: U_WORD
+    bitmask: 0x0100
+    device_class: problem
+    entity_category: diagnostic
+
+  - platform: modbus_controller
+    modbus_controller_id: modbus_outside_unit
+    name: "Voedingsspanning (P10)"
+    register_type: holding
+    address: 2119
+    value_type: U_WORD
+    bitmask: 0x0200
+    device_class: problem
+    entity_category: diagnostic
+
+  - platform: modbus_controller
+    modbus_controller_id: modbus_outside_unit
+    name: "Compressor begrenzing (P11)"
+    register_type: holding
+    address: 2119
+    value_type: U_WORD
+    bitmask: 0x0400
+    device_class: problem
+    entity_category: diagnostic
+
+  - platform: modbus_controller
+    modbus_controller_id: modbus_outside_unit
+    name: "Compressor begrenzing (P12)"
+    register_type: holding
+    address: 2119
+    value_type: U_WORD
+    bitmask: 0x0800
+    device_class: running
+    entity_category: diagnostic
+
+  - platform: modbus_controller
+    modbus_controller_id: modbus_outside_unit
+    name: "Laag drukverschil (P13)"
+    register_type: holding
+    address: 2119
+    value_type: U_WORD
     bitmask: 0x1000
     device_class: problem
     entity_category: diagnostic
@@ -1467,6 +1526,48 @@ number:
       sorting_group_id: settings
 
 - platform: template
+  id: dhw_setpoint_temperature
+  name: "Tapwater temperatuur setpoint"
+  optimistic: True
+  unit_of_measurement: "°C"
+  device_class: "temperature"
+  min_value: 25
+  max_value: 75
+  step: 1
+  initial_value: 55
+  entity_category: config
+  web_server: 
+      sorting_group_id: settings
+
+- platform: template
+  id: dhw_restart_dhw_delta
+  name: "∆T herstart tapwater verwarmen"
+  optimistic: True
+  unit_of_measurement: "°C"
+  device_class: "temperature"
+  min_value: 2
+  max_value: 25
+  step: 1
+  initial_value: 5
+  entity_category: config
+  web_server: 
+      sorting_group_id: settings
+
+- platform: template
+  id: dhw_temperature_threshold_max_compressor_mode
+  name: "Buitentemperatuur Tapwater winter vermogen"
+  optimistic: True
+  unit_of_measurement: "°C"
+  device_class: "temperature"
+  min_value: -20
+  max_value: 10
+  step: 1
+  initial_value: 5
+  entity_category: config
+  web_server: 
+      sorting_group_id: settings
+
+- platform: template
   id: backup_heater_degmin_threshold
   name: "Backup element graadminuten"
   unit_of_measurement: "°C·min"
@@ -1484,6 +1585,20 @@ number:
 - platform: template
   id: pump_speed_heating_number
   name: "Pomp snelheid verwarmen"
+  optimistic: True
+  min_value: 0
+  max_value: 100
+  step: 1
+  unit_of_measurement: "%"
+  initial_value: 100
+  restore_value: True
+  entity_category: config
+  web_server: 
+    sorting_group_id: settings
+
+- platform: template
+  id: pump_speed_dhw_number
+  name: "Pomp snelheid tapwater"
   optimistic: True
   min_value: 0
   max_value: 100
@@ -1578,6 +1693,15 @@ switch:
    restore_mode: RESTORE_DEFAULT_OFF
 
  - platform: template
+   id: dhw_enabled_switch
+   name: "Tapwater aanwezig"
+   optimistic: True
+   restore_mode: RESTORE_DEFAULT_OFF
+   entity_category: config
+   web_server: 
+    sorting_group_id: settings
+
+ - platform: template
    id: amber_controller_active
    name: "Amber controller actief"
    optimistic: True
@@ -1613,6 +1737,15 @@ switch:
    register_type: holding
    web_server: 
      sorting_group_id: control_inside
+
+ - platform: modbus_controller
+   modbus_controller_id: modbus_inside_unit
+   id: dhw_pump_relay_switch
+   name: "Tapwater pomp relais"
+   address: 1102
+   register_type: holding
+   web_server: 
+     sorting_group_id: control_inside
      
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
@@ -1645,6 +1778,18 @@ switch:
 
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
+   internal: True
+   id: three_way_valve_dhw_switch
+   name: "3-weg klep SWW"
+   address: 1112
+   register_type: holding
+   web_server: 
+     sorting_group_id: control_inside
+
+ - platform: modbus_controller
+   modbus_controller_id: modbus_inside_unit
+   internal: True
+   id: three_way_valve_heat_cool_switch
    name: "3-weg klep Koelen/Verwarmen"
    address: 1112
    register_type: holding
@@ -1683,6 +1828,60 @@ select:
         sorting_group_id: settings
 
   - platform: template
+    id: dhw_compressor_mode
+    name: "Tapwater basisvermogen"
+    optimistic: True
+    options:
+      - "Beperkt"
+      - "Zeer laag"
+      - "Laag"
+      - "Gemiddeld"
+      - "Verhoogd"
+      - "Hoog"
+      - "Maximaal"
+    initial_option: "Beperkt"
+    entity_category: config
+    web_server: 
+        sorting_group_id: settings
+
+  - platform: template
+    id: dhw_compressor_mode_max
+    name: "Tapwater wintervermogen"
+    optimistic: True
+    options:
+      - "Gemiddeld"
+      - "Verhoogd"
+      - "Hoog"
+      - "Maximaal"
+    initial_option: "Gemiddeld"
+    entity_category: config
+    web_server: 
+        sorting_group_id: settings
+
+  - platform: template
+    id: three_way_valve_select
+    name: "3-weg klep stand"
+    optimistic: True
+    options:
+      - "Verwarmen/Koelen"
+      - "Tapwater"
+    initial_option: "Verwarmen/Koelen"
+    entity_category: config
+    web_server: 
+      sorting_group_id: control_inside
+    on_value: 
+      then:
+       - if:
+           condition:
+             lambda: 'return id(three_way_valve_select).current_option() == "Verwarmen/Koelen";'
+           then:
+             - switch.turn_off: three_way_valve_dhw_switch
+             - switch.turn_on: three_way_valve_heat_cool_switch
+           else:
+             - switch.turn_on: three_way_valve_dhw_switch
+             - switch.turn_off: three_way_valve_heat_cool_switch
+
+  - platform: template
     id: heat_mode_select
     name: "Verwarmingsmodus"
     optimistic: True
@@ -1710,6 +1909,24 @@ select:
     entity_category: config
     web_server: 
       sorting_group_id: settings
+
+  - platform: modbus_controller
+    id: pump_control_select
+    modbus_controller_id: modbus_inside_unit
+    name: "Pomp stand"
+    address: 1103
+    optionsmap:
+      "Uit": 1000
+      "Onbekend": 950
+      "Laag": 500
+      "Middel": 250
+      "Hoog": 0
+    web_server: 
+     sorting_group_id: control_inside
+    on_value: 
+      then:
+        - lambda: 
+            id(modbus_inside_is_online) = true;
 
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit

--- a/src/openamber.yaml
+++ b/src/openamber.yaml
@@ -1715,6 +1715,16 @@ switch:
 
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
+   internal: True
+   id: three_way_valve_heat_cool_switch
+   name: "3-weg klep Koelen/Verwarmen"
+   address: 1105
+   register_type: holding
+   web_server: 
+     sorting_group_id: control_inside
+
+ - platform: modbus_controller
+   modbus_controller_id: modbus_inside_unit
    id: backup_heater_stage_1
    internal: True
    name: "Backup heater stage 1"
@@ -1738,16 +1748,6 @@ switch:
    internal: True
    id: three_way_valve_dhw_switch
    name: "3-weg klep SWW"
-   address: 1112
-   register_type: holding
-   web_server: 
-     sorting_group_id: control_inside
-
- - platform: modbus_controller
-   modbus_controller_id: modbus_inside_unit
-   internal: True
-   id: three_way_valve_heat_cool_switch
-   name: "3-weg klep Koelen/Verwarmen"
    address: 1112
    register_type: holding
    web_server: 

--- a/src/openamber.yaml
+++ b/src/openamber.yaml
@@ -451,6 +451,9 @@ sensor:
   value_type: S_WORD
   unit_of_measurement: "%"
   state_class: "measurement"
+  filters:
+    - lambda: |-
+        return ((x * -1) + 1000) / 10;
   web_server: 
     sorting_group_id: sensors_inside
   on_value: 
@@ -986,7 +989,6 @@ binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
     name: "Bedrijfstroom warmtepomp (P01)"
-    name: "Bedrijfstroom warmtepomp (P01)"
     register_type: holding
     address: 2119
     bitmask: 0x0001
@@ -1015,7 +1017,6 @@ binary_sensor:
     modbus_controller_id: modbus_outside_unit
     id: oil_return_cycle_active
     name: "Olie-terugloopcyclus (P04)"
-    name: "Olie-terugloopcyclus (P04)"
     icon: mdi:autorenew
     register_type: holding
     address: 2119
@@ -1026,7 +1027,6 @@ binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
     name: "Hogedrukbeveiliging (P05)"
-    name: "Hogedrukbeveiliging (P05)"
     register_type: holding
     address: 2119
     bitmask: 0x0010
@@ -1035,7 +1035,6 @@ binary_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
-    name: "Laag drukverschil (P06)"
     name: "Laag drukverschil (P06)"
     register_type: holding
     address: 2119
@@ -1046,7 +1045,6 @@ binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
     name: "Compressor voorverwarming (P07)"
-    name: "Compressor voorverwarming (P07)"
     register_type: holding
     address: 2119
     bitmask: 0x0040
@@ -1055,7 +1053,6 @@ binary_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit
-    name: "Storing sensor persgasdruk (P08)"
     name: "Storing sensor persgasdruk (P08)"
     register_type: holding
     address: 2119
@@ -1104,47 +1101,6 @@ binary_sensor:
     name: "Laag drukverschil (P13)"
     register_type: holding
     address: 2119
-    value_type: U_WORD
-    bitmask: 0x0100
-    device_class: problem
-    entity_category: diagnostic
-
-  - platform: modbus_controller
-    modbus_controller_id: modbus_outside_unit
-    name: "Voedingsspanning (P10)"
-    register_type: holding
-    address: 2119
-    value_type: U_WORD
-    bitmask: 0x0200
-    device_class: problem
-    entity_category: diagnostic
-
-  - platform: modbus_controller
-    modbus_controller_id: modbus_outside_unit
-    name: "Compressor begrenzing (P11)"
-    register_type: holding
-    address: 2119
-    value_type: U_WORD
-    bitmask: 0x0400
-    device_class: problem
-    entity_category: diagnostic
-
-  - platform: modbus_controller
-    modbus_controller_id: modbus_outside_unit
-    name: "Compressor begrenzing (P12)"
-    register_type: holding
-    address: 2119
-    value_type: U_WORD
-    bitmask: 0x0800
-    device_class: running
-    entity_category: diagnostic
-
-  - platform: modbus_controller
-    modbus_controller_id: modbus_outside_unit
-    name: "Laag drukverschil (P13)"
-    register_type: holding
-    address: 2119
-    value_type: U_WORD
     bitmask: 0x1000
     device_class: problem
     entity_category: diagnostic
@@ -1705,15 +1661,12 @@ switch:
    id: amber_controller_active
    name: "Amber controller actief"
    optimistic: True
-   on_turn_on: 
-     then:
-      # Initialize board relays
-      - switch.turn_on: pump_p0_relay_switch
-      - switch.turn_on: initialize_step_4
+   restore_mode: ALWAYS_ON
 
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
    id: pump_p0_relay_switch
+   internal: True
    name: "Pomp P0 relais"
    address: 1099
    register_type: holding
@@ -1723,6 +1676,7 @@ switch:
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
    id: pump_p1_relay_switch
+   internal: True
    name: "Pomp P1 relais"
    address: 1100
    register_type: holding
@@ -1732,6 +1686,7 @@ switch:
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
    id: pump_p2_relay_switch
+   internal: True
    name: "Pomp P2 relais"
    address: 1101
    register_type: holding
@@ -1741,6 +1696,7 @@ switch:
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
    id: dhw_pump_relay_switch
+   internal: True
    name: "Tapwater pomp relais"
    address: 1102
    register_type: holding
@@ -1749,8 +1705,9 @@ switch:
      
  - platform: modbus_controller
    modbus_controller_id: modbus_inside_unit
-   id: initialize_step_4
-   name: "Binnen unit Onbekend #4"
+   id: initialize_relay_switch
+   internal: True
+   name: "Binnen unit relais onbekend"
    address: 1104
    register_type: holding
    web_server: 
@@ -1909,24 +1866,6 @@ select:
     entity_category: config
     web_server: 
       sorting_group_id: settings
-
-  - platform: modbus_controller
-    id: pump_control_select
-    modbus_controller_id: modbus_inside_unit
-    name: "Pomp stand"
-    address: 1103
-    optionsmap:
-      "Uit": 1000
-      "Onbekend": 950
-      "Laag": 500
-      "Middel": 250
-      "Hoog": 0
-    web_server: 
-     sorting_group_id: control_inside
-    on_value: 
-      then:
-        - lambda: 
-            id(modbus_inside_is_online) = true;
 
   - platform: modbus_controller
     modbus_controller_id: modbus_outside_unit


### PR DESCRIPTION
This PR implements initial simpel support for domestic hot water. No priority rules implemented yet.

DHW will be heated on a fixed frequency set by the dhw_compressor_mode setting, it can switch to dhw_compressor_mode_max setting whenever the outside temperature is below dhw_temperature_threshold_max_compressor_mode setting.