### PR TITLE
Added anti legionella schedule

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ jobs:
       files: |
         src/openamber-leejow.yaml
         src/openamber-waveshare-display.yaml
-      esphome-version: 2026.1.0
+      esphome-version: 2026.1.1
       combined-name: openamber
       release-summary: ${{ github.event.release.body }}
       release-url: ${{ github.event.release.html_url }}

--- a/src/common/binary_sensors.yaml
+++ b/src/common/binary_sensors.yaml
@@ -303,7 +303,7 @@
 
 - platform: modbus_controller
   modbus_controller_id: modbus_outside_unit
-  name: "Storing sensor verdamper/condensor (P09)"
+  name: "Storing sensor verdamper⁄condensor (P09)"
   register_type: holding
   address: 2119
   bitmask: 0x0100
@@ -357,7 +357,7 @@
 
 - platform: modbus_controller
   modbus_controller_id: modbus_outside_unit
-  name: "Storing sensor verdamper/condensor (F02)"
+  name: "Storing sensor verdamper⁄condensor (F02)"
   register_type: holding
   address: 2120
   bitmask: 0x0002

--- a/src/common/numbers.yaml
+++ b/src/common/numbers.yaml
@@ -330,3 +330,27 @@
   entity_category: config
   web_server: 
     sorting_group_id: settings
+
+- platform: template
+  id: legio_repeat_days_number
+  name: "Legionellapreventie herhaling (dagen)"
+  unit_of_measurement: "d"
+  min_value: 7
+  max_value: 60
+  step: 1
+  restore_value: True
+  initial_value: 7
+  optimistic: True
+  mode: box
+
+- platform: template
+  id: legio_target_temperature_number
+  name: "Legionellapreventie doeltemperatuur"
+  unit_of_measurement: "°C"
+  device_class: "temperature"
+  min_value: 55
+  max_value: 65
+  step: 1
+  initial_value: 60
+  restore_value: True
+  optimistic: True

--- a/src/common/openamber.yaml
+++ b/src/common/openamber.yaml
@@ -77,6 +77,20 @@ globals:
     restore_value: no
     initial_value: 'false'
 
+datetime:
+ - platform: template
+   id: next_legionella_run
+   name: "Volgende legionellapreventie"
+   type: datetime
+   restore_value: true
+   optimistic: true
+   initial_value: "2026-01-01 10:00:00"
+
+# Use SNTP for time so we also have time when not connected to Home Assistant.
+time:
+  - platform: sntp
+    id: my_time
+
 modbus:
   send_wait_time: 500ms
 

--- a/src/common/selects.yaml
+++ b/src/common/selects.yaml
@@ -51,9 +51,9 @@
   name: "3-weg klep stand"
   optimistic: True
   options:
-    - "Verwarmen/Koelen"
+    - "Verwarmen⁄Koelen"
     - "Tapwater"
-  initial_option: "Verwarmen/Koelen"
+  initial_option: "Verwarmen⁄Koelen"
   entity_category: config
   web_server: 
     sorting_group_id: control_inside
@@ -61,7 +61,7 @@
     then:
       - if:
           condition:
-            lambda: 'return id(three_way_valve_select).current_option() == "Verwarmen/Koelen";'
+            lambda: 'return id(three_way_valve_select).current_option() == "Verwarmen⁄Koelen";'
           then:
             - switch.turn_off: three_way_valve_dhw_switch
             - switch.turn_on: three_way_valve_heat_cool_switch

--- a/src/common/sensors.yaml
+++ b/src/common/sensors.yaml
@@ -1,6 +1,6 @@
 - platform: template
   id: backup_heater_degmin_current_sensor
-  name: "Backup heater degree/min current"
+  name: "Backup heater degree⁄min current"
   unit_of_measurement: "°C·min"
   accuracy_decimals: 1
   state_class: measurement

--- a/src/common/switches.yaml
+++ b/src/common/switches.yaml
@@ -1,4 +1,13 @@
 - platform: template
+  id: legio_enabled_switch
+  name: "Legionellapreventie"
+  optimistic: True
+  restore_mode: RESTORE_DEFAULT_OFF
+  entity_category: config
+  web_server: 
+    sorting_group_id: settings
+
+- platform: template
   id: dhw_enabled_switch
   name: "Tapwater aanwezig"
   optimistic: True
@@ -67,7 +76,7 @@
   modbus_controller_id: modbus_inside_unit
   internal: True
   id: three_way_valve_heat_cool_switch
-  name: "3-weg klep Koelen/Verwarmen"
+  name: "3-weg klep Koelen⁄Verwarmen"
   address: 1105
   register_type: holding
   web_server: 


### PR DESCRIPTION
Added settings to configure when to run anti legionella program.
- next_legionella_run
Datetime sensor which can be set to on what date and time the next legionella run should take place.
- legio_target_temperature_number
Target temperature for hot water used when legionella run is active.
- legio_repeat_days_number
Interval in days when the legionella run should be scheduled again.