### PR TITLE
Implement Opt-In analytics

### DIFF
--- a/src/common/binary_sensors.yaml
+++ b/src/common/binary_sensors.yaml
@@ -6,8 +6,16 @@
       float restart_delta = id(dhw_restart_dhw_delta).state;
       float tw = id(dhw_temperature_tw_sensor).state;
       float setpoint = id(dhw_setpoint_temperature).state;
+      bool legio_run_active = id(dhw_legionella_run_active_sensor).state;
+      float legio_target = id(legio_target_temperature_number).state;      
 
-      return (setpoint - tw) >= restart_delta;
+      return (setpoint - tw) >= restart_delta ||
+             (legio_run_active && tw < legio_target);
+
+- platform: template
+  name: "Legionellacyclus actief"
+  id: dhw_legionella_run_active_sensor
+  device_class: running
 
 - platform: template
   name: "Warmtevraag"

--- a/src/common/numbers.yaml
+++ b/src/common/numbers.yaml
@@ -343,6 +343,9 @@
   initial_value: 7
   optimistic: True
   mode: box
+  entity_category: config
+  web_server: 
+    sorting_group_id: settings
 
 - platform: template
   id: legio_target_temperature_number
@@ -355,3 +358,6 @@
   initial_value: 60
   restore_value: True
   optimistic: True
+  entity_category: config
+  web_server: 
+    sorting_group_id: settings

--- a/src/common/numbers.yaml
+++ b/src/common/numbers.yaml
@@ -120,7 +120,7 @@
 
 - platform: template
   id: heat_curve_0
-  name: "Stooklijn Tc  0°C"
+  name: "Stooklijn Tc @ 0°C"
   optimistic: True
   unit_of_measurement: "°C"
   device_class: "temperature"
@@ -175,6 +175,7 @@
   max_value: 75
   step: 1
   initial_value: 55
+  restore_value: True
   entity_category: config
   web_server: 
       sorting_group_id: settings

--- a/src/common/openamber.yaml
+++ b/src/common/openamber.yaml
@@ -1,17 +1,37 @@
+substitutions:
+  device_name: openamber
+  device_friendly_name: OpenAmber
+  device_project_name: jordi.openamber
+  device_version: 0.0.6
+
 esphome:
-  name: openamber
-  friendly_name: OpenAmber
+  name: ${device_name}
+  friendly_name: ${device_friendly_name}
   project:
-    name: jordi.openamber
-    version: 0.0.5
+    name: ${device_project_name}
+    version: ${device_version}
   includes: 
     - common/openamber.h
-
+  on_boot:
+    if:
+      condition:
+        - switch.is_on: analytics_enabled_switch
+      then:
+        - mqtt.enable:
 esp32:
   framework:
     type: esp-idf
+    advanced:
+      minimum_chip_revision: "3.1"
 
 interval:
+  - interval: 5min
+    then:
+      - if:
+         condition:
+          - switch.is_on: analytics_enabled_switch
+         then:
+          - script.execute: send_analytics
   - interval: 10s
     then:
       - if:
@@ -28,6 +48,19 @@ logger:
   baud_rate: 0
 
 api:
+
+# Broker used to push analytics data (Opt-In)
+mqtt:
+  broker: mqtt.openamber.nl
+  enabled_on_boot: false
+  username: openamber_write
+  password: openamber
+  discovery: false
+  discover_ip: false
+  discovery_retain: false
+  idf_send_async: true
+  log_topic: null
+  topic_prefix: null
 
 ota:
   - platform: esphome

--- a/src/common/openamber.yaml
+++ b/src/common/openamber.yaml
@@ -21,8 +21,6 @@ esphome:
 esp32:
   framework:
     type: esp-idf
-    advanced:
-      minimum_chip_revision: "3.1"
 
 interval:
   - interval: 5min
@@ -52,7 +50,7 @@ api:
 # Broker used to push analytics data (Opt-In)
 mqtt:
   broker: mqtt.openamber.nl
-  enabled_on_boot: false
+  enable_on_boot: false
   username: openamber_write
   password: openamber
   discovery: false
@@ -166,6 +164,7 @@ binary_sensor: !include binary_sensors.yaml
 number: !include numbers.yaml
 switch: !include switches.yaml
 select: !include selects.yaml
+script: !include scripts.yaml
 
 output:
   - platform: template

--- a/src/common/scripts.yaml
+++ b/src/common/scripts.yaml
@@ -1,0 +1,65 @@
+- id: send_analytics
+  then:
+    - mqtt.publish_json:
+        topic: !lambda |-
+          return "openamber/" + id(mac_address).state;
+        qos: 1
+        retain: true
+        payload: |-
+          root["device_id"] = id(mac_address).state;
+          root["timestamp"] = id(my_time).timestamp_now();
+          root["firmware"] = "${device_version}";
+          root["hardware_item_number"] = id(outside_unit_hardware_item_number).state;
+          root["eeprom_version"] = id(outside_unit_eeprom_version).state;
+          root["outside_unit_eeprom_version_part1"] = id(outside_unit_eeprom_version_part1).state;
+          root["outside_unit_eeprom_version_part2"] = id(outside_unit_eeprom_version_part2).state;
+          root["program_version"] = id(outside_unit_program_version).state;
+          root["dhw_enabled"] = id(dhw_enabled_switch).state;
+          root["legio_enabled"] = id(legio_enabled_switch).state;
+          root["frost_protection_stage_1_temp_ta"] = id(frost_protection_stage_1_temp_ta).state;
+          root["frost_protection_stage_2_temp_ta"] = id(frost_protection_stage_2_temp_ta).state;
+          root["frost_protection_stage_2_temp_tui"] = id(frost_protection_stage_2_temp_tui).state;
+          root["compressor_start_delta"] = id(compressor_start_delta).state;
+          root["compressor_stop_delta"] = id(compressor_stop_delta).state;
+          root["heat_curve_p15"] = id(heat_curve_p15).state;
+          root["heat_curve_p10"] = id(heat_curve_p10).state;
+          root["heat_curve_p5"] = id(heat_curve_p5).state;
+          root["heat_curve_0"] = id(heat_curve_0).state;
+          root["heat_curve_m10"] = id(heat_curve_m10).state;
+          root["dhw_setpoint_temperature"] = id(dhw_setpoint_temperature).state;
+          root["dhw_restart_dhw_delta"] = id(dhw_restart_dhw_delta).state;
+          root["dhw_temperature_threshold_max_compressor_mode"] = id(dhw_temperature_threshold_max_compressor_mode).state;
+          root["dhw_backup_min_avg_rate"] = id(dhw_backup_min_avg_rate).state;
+          root["backup_heater_degmin_threshold"] = id(backup_heater_degmin_threshold).state;
+          root["pump_speed_heating"] = id(pump_speed_heating_number).state;
+          root["pump_speed_dhw"] = id(pump_speed_dhw_number).state;
+          root["pump_interval"] = id(pump_interval).state;
+          root["pump_duration"] = id(pump_duration).state;
+          root["defrost_backup_heater_boost_temperature"] = id(defrost_backup_heater_boost_temperature_sensor).state;
+          root["legio_repeat_days"] = id(legio_repeat_days_number).state;
+          root["legio_target_temperature"] = id(legio_target_temperature_number).state;
+          root["heat_compressor_mode"] = id(heat_compressor_mode).current_option();
+          root["dhw_compressor_mode"] = id(dhw_compressor_mode).current_option();
+          root["dhw_compressor_mode_max"] = id(dhw_compressor_mode_max).current_option();
+          root["heat_mode"] = id(heat_mode_select).current_option();
+          root["thermostat_mode"] = id(thermostat_mode_select).current_option();
+          root["heat_demand"] = id(heat_demand_active_sensor).state;
+          root["cool_demand"] = id(cool_demand_active_sensor).state;
+          root["dhw_demand"] = id(dhw_demand_active_sensor).state;
+          root["backup_heater_active"] = id(backup_heater_active_sensor).state;
+          root["internal_pump_active"] = id(internal_pump_active).state;
+          root["defrost_active"] = id(defrost_active_sensor).state;
+          root["backup_heater_degmin_current"] = id(backup_heater_degmin_current_sensor).state;
+          root["dhw_backup_current_avg_rate"] = id(dhw_backup_current_avg_rate_sensor).state;
+          root["state_machine_state"] = id(state_machine_state).state;
+          root["current_setpoint"] = id(current_setpoint).state;
+          root["room_temperature"] = id(room_temperature).state;
+          root["temperature_outside_ta"] = id(temperature_outside_ta).state;
+          root["dhw_temperature_tw"] = id(dhw_temperature_tw_sensor).state;
+          root["heat_cool_temperature_tc"] = id(heat_cool_temperature_tc).state;
+          root["outlet_temperature_tuo"] = id(outlet_temperature_tuo).state;
+          root["inlet_temperature_tui"] = id(inlet_temperature_tui).state;
+          root["pump_p0_current_pwm"] = id(pump_p0_current_pwm_sensor).state;
+          root["current_compressor_frequency"] = id(current_compressor_frequency).state;
+          root["condensate_temperature_tup"] = id(condensate_temperature_tup).state;
+          root["evaporation_temperature_tp"] = id(evaporation_temperature_tp).state;

--- a/src/common/sensors.yaml
+++ b/src/common/sensors.yaml
@@ -7,7 +7,7 @@
 
 - platform: template
   id: dhw_backup_current_avg_rate_sensor
-  name: "DHW current avg rate"
+  name: "DHW verwarmsnelheid"
   unit_of_measurement: "°C/min"
   accuracy_decimals: 2
   state_class: measurement
@@ -193,6 +193,7 @@
 
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
+  id: condensate_temperature_tup
   name: "Condensatietemperatuur (Tup)"
   address: 1204
   register_type: holding
@@ -351,14 +352,6 @@
 
 - platform: modbus_controller
   modbus_controller_id: modbus_outside_unit
-  name: "Buiten unit state"
-  register_type: holding
-  address: 2108
-  web_server: 
-    sorting_group_id: sensors_outside
-
-- platform: modbus_controller
-  modbus_controller_id: modbus_outside_unit
   id: temperature_outside_ta
   name: "Buitentemperatuur (Ta)"
   address: 2110
@@ -376,6 +369,7 @@
 
 - platform: modbus_controller
   modbus_controller_id: modbus_outside_unit
+  id: evaporation_temperature_tp
   name: "Verdampingstemperatuur (Tp)"
   address: 2111
   register_type: holding
@@ -465,9 +459,22 @@
 
 - platform: modbus_controller
   modbus_controller_id: modbus_outside_unit
+  id: outside_unit_eeprom_version
   name: "EEPROM"
   skip_updates: 10
   address: 2123
+  register_type: holding
+  value_type: S_WORD
+  web_server: 
+    sorting_group_id: sensors_outside
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  name: "Hardware item nummer"
+  id: outside_unit_hardware_item_number
+  #internal: True
+  skip_updates: 10
+  address: 2127
   register_type: holding
   value_type: S_WORD
   web_server: 

--- a/src/common/switches.yaml
+++ b/src/common/switches.yaml
@@ -17,6 +17,24 @@
     sorting_group_id: settings
 
 - platform: template
+  id: analytics_enabled_switch
+  name: "Analytics versturen"
+  optimistic: True
+  restore_mode: RESTORE_DEFAULT_OFF
+  entity_category: config
+  web_server: 
+    sorting_group_id: settings
+  on_state:
+    then:
+      - if:
+          condition:
+            - switch.is_on: analytics_enabled_switch
+          then:
+            - mqtt.enable:
+          else:
+            - mqtt.disable:
+
+- platform: template
   id: amber_controller_active
   name: "Amber controller actief"
   optimistic: True

--- a/src/common/text_sensors.yaml
+++ b/src/common/text_sensors.yaml
@@ -1,26 +1,31 @@
-  - platform: template
-    name: "Buiten unit EEPROM versie"
-    update_interval: 60s
-    web_server: 
-     sorting_group_id: sensors_outside
-    lambda: |-
-      if (!id(outside_unit_program_version).has_state() ||
-          !id(outside_unit_eeprom_version_part1).has_state() ||
-          !id(outside_unit_eeprom_version_part2).has_state()) {
-        return {};
-      }
+- platform: template
+  name: "Buiten unit EEPROM versie"
+  update_interval: 60s
+  web_server: 
+    sorting_group_id: sensors_outside
+  lambda: |-
+    if (!id(outside_unit_program_version).has_state() ||
+        !id(outside_unit_eeprom_version_part1).has_state() ||
+        !id(outside_unit_eeprom_version_part2).has_state()) {
+      return {};
+    }
 
-      int v1 = (int)id(outside_unit_program_version).state;
-      int v2 = (int)id(outside_unit_eeprom_version_part1).state;
-      int v3 = (int)id(outside_unit_eeprom_version_part2).state;
+    int v1 = (int)id(outside_unit_program_version).state;
+    int v2 = (int)id(outside_unit_eeprom_version_part1).state;
+    int v3 = (int)id(outside_unit_eeprom_version_part2).state;
 
-      char buffer[20];
-      snprintf(buffer, sizeof(buffer), "V%04X,%d%d", v1, v2, v3);
-      return std::string(buffer);
-    icon: "mdi:chip"
+    char buffer[20];
+    snprintf(buffer, sizeof(buffer), "V%04X,%d%d", v1, v2, v3);
+    return std::string(buffer);
+  icon: "mdi:chip"
 
-  - platform: template
-    id: state_machine_state
-    name: "Control loop state"
-    icon: "mdi:state-machine"
-    update_interval: never
+- platform: template
+  id: state_machine_state
+  name: "Control loop state"
+  icon: "mdi:state-machine"
+  update_interval: never
+
+- platform: wifi_info
+  mac_address:
+    id: mac_address
+    internal: True

--- a/src/openamber-leejow.yaml
+++ b/src/openamber-leejow.yaml
@@ -3,6 +3,9 @@ packages:
 
 esp32:
   board: esp32dev
+  framework:
+    advanced:
+      minimum_chip_revision: "3.1"
     
 modbus:
   flow_control_pin: GPIO14


### PR DESCRIPTION
Added Opt-In analytics
Some minor fixes for previous added features.

Analytics contains metrics of the heatpump performance and settings to be able to monitor remotely and compare data with community.

This can be enabled by toggling analytics_enabled_switch.