### PR TITLE
Implement support for heat/cool demand from external sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Connect wires to your hardware RS485 port (Itho Daalderop Amber Control Module u
 | Address    | Function                            |
 |:----------:|:-----------------------------------------------------------------:|
 | 1999       | Compressor mode(0-10)                                             |
-| 3999       | Working mode(0=OFF,1=COOL,3=HEAT,5=EEPROM UPDATE,6=MAINTENANCE)   |
+| 3999       | Working mode(0=OFF,1=COOL,2=HEAT,5=EEPROM UPDATE,6=MAINTENANCE)   |
 
 #### State (Address 2108)
 

--- a/src/common/binary_sensors.yaml
+++ b/src/common/binary_sensors.yaml
@@ -28,7 +28,7 @@
     }
     else
     {
-      return id(external_heat_demand).state;
+      return id(external_heat_demand_wired).state || id(external_heat_demand_switch).state;
     }
 
 - platform: template
@@ -42,7 +42,7 @@
     }
     else
     {
-      return id(external_cool_demand).state;
+      return id(external_cool_demand_wired).state || id(external_cool_demand_switch).state;
     }
 
 - platform: template
@@ -88,8 +88,8 @@
 
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
-  id: external_cool_demand
-  name: "Externe koudevraag"
+  id: external_cool_demand_wired
+  name: "Externe koudevraag (bedraad)"
   address: 1213
   register_type: holding
   device_class: running
@@ -98,8 +98,8 @@
 
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
-  id: external_heat_demand
-  name: "Externe warmtevraag"
+  id: external_heat_demand_wired
+  name: "Externe warmtevraag (bedraad)"
   address: 1214
   register_type: holding
   device_class: running

--- a/src/common/switches.yaml
+++ b/src/common/switches.yaml
@@ -142,3 +142,13 @@
     - switch.control:
         id: backup_heater_stage_2
         state: !lambda return x;
+
+- platform: template
+  id: heat_demand_switch
+  name: "Externe verwarmingsvraag"
+  optimistic: True
+
+- platform: template
+  id: cool_demand_switch
+  name: "Externe koudevraag"
+  optimistic: True


### PR DESCRIPTION
Adds two switches
- heat_demand_switch
- cool_demand_switch

When thermostat_mode_select is in External mode, these switches will trigger the demand. This can be used when there is no wiring connected to the demand inputs of the inside unit. For example to use a generic thermostat in HomeAssistant.