### PR TITLE
Change thermostat mode default to External

### DIFF
--- a/src/common/selects.yaml
+++ b/src/common/selects.yaml
@@ -91,7 +91,7 @@
   options:
     - "Intern"
     - "Extern"
-  initial_option: "Intern"
+  initial_option: "Extern"
   restore_value: True
   entity_category: config
   web_server: 


### PR DESCRIPTION
Reason for this is that whenever there is no Tr sensor it will instantly have heat demand after initial install. And most users probably have a thermostat connected to it.