### PR TITLE
Improved DHW pump start logic and added different start modes

### DIFF
--- a/src/common/selects.yaml
+++ b/src/common/selects.yaml
@@ -47,6 +47,18 @@
       sorting_group_id: dhw_settings
 
 - platform: template
+  id: dhw_pump_start_mode_select
+  name: "Tapwater pomp startmodus"
+  optimistic: True
+  options:
+    - "Aanvoer warmer dan vat (ΔT)"
+    - "Samen met compressor"
+  initial_option: "Aanvoer warmer dan vat (ΔT)"
+  entity_category: config
+  web_server: 
+      sorting_group_id: dhw_settings
+
+- platform: template
   id: three_way_valve_select
   name: "3-weg klep stand"
   internal: True


### PR DESCRIPTION
This PR adds a new setting "dhw_pump_start_mode", this setting changes when the DHW pump will start.
By default it will start whenever the supply temperature (Tuo) is higher than Tw sensor. You can also set the setting to start together with the compressor.