### PR TITLE
Implement SmartGrid Ready modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Supply temperature regulation with PID-based compressor Hz modulation
 - Boost after defrost using backup heater.
 - Sensors for error codes
 - Support external thermostats (Heating/Cooling input)
+- Support SG-Ready
 
 ## Todo
 - Support cooling
 - Tv1/Tv2 buffer support
-- Support Smart Grid inputs
 - Extend configuration options
 - Error handling
 - Support OpenTherm thermostats
@@ -40,14 +40,20 @@ Supply temperature regulation with PID-based compressor Hz modulation
 The firmware can be used on any ESP32 with an RS485 board.
 
 ### Off-the-shelf boards:
-#### Itho Daalderop Amber Control Module (https://electropaultje.nl/product/itho-daalderop-amber-control-module/)
-The firmware in this repository targets this module, I currently use this as well.
 
-#### Waveshare ESP32-S3 Touch LCD 5'' (https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-5)
-This is the best replacement for the WinCE controller as there is a touchscreen, RS485 and 24V input available.
-We would also need a 3D printed bracket to mount it properly.
+#### Waveshare ESP32-S3 Touch LCD 5'' (https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-5) (1024x600 resolution is preferred)
+Binary: openamber-esp32s3
+
+This is the preferred replacement for the WinCE controller as there is a touchscreen, RS485 and 24V input available.
+So the controller can be powered by the same cables which are now powering the WinCE controller.
+A 3D printed bracket to mount it properly is required.
 
 ![UI](/docs/images/openamber-waveshare-display-ui.png)
+
+#### Itho Daalderop Amber Control Module (https://electropaultje.nl/product/itho-daalderop-amber-control-module/)
+Binary: openamber-esp32
+
+This can be used to run OpenAmber however it is not an ideal replacement of the WinCE Controller as there is no screen.
 
 ## Installation
 **Software**
@@ -87,9 +93,11 @@ When using the Waveshare ESP32-S3 Touch LCD 5'' you need to set the RS485 resist
 | 1203       | Inlet water temperature (Tui)       |
 | 1204       | Outdoor coil temperature (Tp)       |
 | 1207       | Outdoor coil temperature (Tv1)      |
+| 1211       | SmartGrid Ready SGA                 | 
 | 1212       | Pump P0 active                      |
 | 1213       | External cooling signal             |
 | 1214       | External heating signal             |
+| 1220       | SmartGrid Ready SGB                 | 
 | 1300       | Pump P1 active                      |
 | 1301       | Pump P2 active                      |
 | 1302       | DHW pump active                     |

--- a/src/common/binary_sensors.yaml
+++ b/src/common/binary_sensors.yaml
@@ -107,6 +107,7 @@
 - platform: template
   name: "SG-Ready blokkeermodus"
   id: sg_ready_block_mode_active_sensor
+  disabled_by_default: True
   device_class: running
   lambda: |-
     return id(sg_ready_mode_select).current_option() == "Blokkeren" ||
@@ -117,6 +118,7 @@
 - platform: template
   name: "SG-Ready boostmodus"
   id: sg_ready_boost_mode_active_sensor
+  disabled_by_default: True
   device_class: running
   lambda: |-
     return id(sg_ready_mode_select).current_option() == "Boost" ||
@@ -127,6 +129,7 @@
 - platform: template
   name: "SG-Ready maxboostmodus"
   id: sg_ready_max_boost_mode_active_sensor
+  disabled_by_default: True
   device_class: running
   lambda: |-
     return id(sg_ready_mode_select).current_option() == "Max Boost" ||
@@ -137,7 +140,7 @@
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
   id: sg_ready_a_active_sensor
-  internal: true
+  internal: True
   name: "SG-Ready A"
   address: 1211
   register_type: holding
@@ -158,7 +161,7 @@
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
   id: external_cool_demand_wired
-  internal: true
+  internal: True
   name: "Externe koudevraag (bedraad)"
   address: 1213
   register_type: holding
@@ -169,7 +172,7 @@
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
   id: external_heat_demand_wired
-  internal: true
+  internal: True
   name: "Externe warmtevraag (bedraad)"
   address: 1214
   register_type: holding

--- a/src/common/binary_sensors.yaml
+++ b/src/common/binary_sensors.yaml
@@ -10,6 +10,11 @@
       float legio_target = id(legio_target_temperature_number).state;
       bool dhw_enabled = id(dhw_enabled_switch).state;
 
+      if(id(sg_ready_block_mode_active_sensor).state)
+      {
+        return false;
+      }
+
       return dhw_enabled && ((setpoint - tw) >= restart_delta ||
              (legio_run_active && tw < legio_target));
   web_server: 
@@ -27,6 +32,11 @@
   id: heat_demand_active_sensor
   device_class: running
   lambda: |-
+    if(id(sg_ready_block_mode_active_sensor).state)
+    {
+      return false;
+    }
+
     if (id(thermostat_mode_select).current_option() == "Intern")
     {
       return id(climate_controller).action == climate::CLIMATE_ACTION_HEATING;
@@ -43,6 +53,11 @@
   id: cool_demand_active_sensor
   device_class: running
   lambda: |-
+    if(id(sg_ready_block_mode_active_sensor).state)
+    {
+      return false;
+    }
+
     if (id(thermostat_mode_select).current_option() == "Intern")
     {
       return id(climate_controller).action == climate::CLIMATE_ACTION_COOLING;
@@ -89,6 +104,47 @@
   web_server: 
     sorting_group_id: overview
 
+- platform: template
+  name: "SG-Ready blokkeermodus"
+  id: sg_ready_block_mode_active_sensor
+  device_class: running
+  lambda: |-
+    return id(sg_ready_mode_select).current_option() == "Blokkeren" ||
+           (id(sg_ready_a_active_sensor).state && !id(sg_ready_b_active_sensor).state);
+  web_server: 
+    sorting_group_id: diagnostic
+
+- platform: template
+  name: "SG-Ready boostmodus"
+  id: sg_ready_boost_mode_active_sensor
+  device_class: running
+  lambda: |-
+    return id(sg_ready_mode_select).current_option() == "Boost" ||
+           (!id(sg_ready_a_active_sensor).state && id(sg_ready_b_active_sensor).state);
+  web_server: 
+    sorting_group_id: diagnostic
+
+- platform: template
+  name: "SG-Ready maxboostmodus"
+  id: sg_ready_max_boost_mode_active_sensor
+  device_class: running
+  lambda: |-
+    return id(sg_ready_mode_select).current_option() == "Max Boost" ||
+           (id(sg_ready_a_active_sensor).state && id(sg_ready_b_active_sensor).state);
+  web_server: 
+    sorting_group_id: diagnostic
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_inside_unit
+  id: sg_ready_a_active_sensor
+  internal: true
+  name: "SG-Ready A"
+  address: 1211
+  register_type: holding
+  device_class: running
+  web_server: 
+    sorting_group_id: diagnostic
+
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
   id: internal_pump_active
@@ -102,7 +158,7 @@
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
   id: external_cool_demand_wired
-  disabled_by_default: true
+  internal: true
   name: "Externe koudevraag (bedraad)"
   address: 1213
   register_type: holding
@@ -113,9 +169,20 @@
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit
   id: external_heat_demand_wired
-  disabled_by_default: true
+  internal: true
   name: "Externe warmtevraag (bedraad)"
   address: 1214
+  register_type: holding
+  device_class: running
+  web_server: 
+    sorting_group_id: diagnostic
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_inside_unit
+  id: sg_ready_b_active_sensor
+  internal: True
+  name: "SG-Ready B"
+  address: 1220
   register_type: holding
   device_class: running
   web_server: 

--- a/src/common/numbers.yaml
+++ b/src/common/numbers.yaml
@@ -358,3 +358,33 @@
   entity_category: config
   web_server: 
     sorting_group_id: dhw_settings
+
+- platform: template
+  id: sg_ready_heating_boost_temperature_number
+  name: "SG-Ready verwarmingsboost setpoint"
+  optimistic: True
+  restore_value: True
+  initial_value: 5
+  step: 1
+  min_value: 0
+  max_value: 10
+  unit_of_measurement: "°C"
+  device_class: "temperature"
+  entity_category: config
+  web_server: 
+    sorting_group_id: heating_settings
+
+- platform: template
+  id: sg_ready_dhw_boost_temperature_number
+  name: "SG-Ready tapwaterboost setpoint"
+  optimistic: True
+  restore_value: True
+  initial_value: 5
+  step: 1
+  min_value: 0
+  max_value: 10
+  unit_of_measurement: "°C"
+  device_class: "temperature"
+  entity_category: config
+  web_server: 
+    sorting_group_id: dhw_settings

--- a/src/common/selects.yaml
+++ b/src/common/selects.yaml
@@ -109,6 +109,21 @@
   web_server: 
     sorting_group_id: heating_settings
 
+- platform: template
+  id: sg_ready_mode_select
+  name: "SG-Ready modus"
+  optimistic: True
+  options:
+    - "Normaal"
+    - "Blokkeren"
+    - "Boost"
+    - "Max boost"
+  initial_option: "Normaal"
+  restore_value: True
+  entity_category: config
+  web_server: 
+    sorting_group_id: manual_control
+
 - platform: modbus_controller
   modbus_controller_id: modbus_outside_unit
   id: compressor_control_select

--- a/src/common/sensors.yaml
+++ b/src/common/sensors.yaml
@@ -63,19 +63,53 @@
   accuracy_decimals: 0
   update_interval: never
   lambda: |-
+    float setpoint = 0.0;
     if (id(heat_mode_select).current_option() == "Stooklijn")
     {
-      return id(heat_curve_calculated_setpoint).state;
+      setpoint = id(heat_curve_calculated_setpoint).state;
     }
     else
     {
-      return id(manual_setpoint).state;
+      setpoint = id(manual_setpoint).state;
     }
+
+    if(id(sg_ready_boost_mode_active_sensor).state || id(sg_ready_max_boost_mode_active_sensor).state)
+    {
+      setpoint += id(sg_ready_heating_boost_temperature_number).state;
+    }
+
+    return setpoint;
   on_value:
     - lambda: |-
         auto call = id(pid_heat_cool_temperature_control).make_call();
         call.set_target_temperature(x);
         call.perform();
+  web_server: 
+    sorting_group_id: overview
+
+- platform: template
+  id: current_dhw_setpoint_sensor
+  name: "Huidig tapwater setpoint"
+  unit_of_measurement: "°C"
+  accuracy_decimals: 0
+  update_interval: never
+  lambda: |-
+    float setpoint = 0.0;
+    if (id(dhw_legionella_run_active_sensor).state)
+    {
+      setpoint = id(legio_target_temperature_number).state;
+    }
+    else
+    {
+      setpoint = id(dhw_setpoint_temperature).state;
+    }
+
+    if(id(sg_ready_boost_mode_active_sensor).state || id(sg_ready_max_boost_mode_active_sensor).state)
+    {
+      setpoint += id(sg_ready_dhw_boost_temperature_number).state;
+    }
+
+    return setpoint;
   web_server: 
     sorting_group_id: overview
 


### PR DESCRIPTION
Implements SG-Ready modes:
- Blocked: Blocks demand for DHW and heating
- Boost: Boosts setpoints of heating and DHW according to settings sg_ready_heating_boost_temperature_number and sg_ready_dhw_boost_temperature_number
- Max boost: Same as boost but also use backup heater.

Added setting sg_ready_mode_select to force SG-Ready modes without having to trigger the inputs on the inside unit.