### PR TITLE
Improve DHW backup heater calculations

### DIFF
--- a/src/openamber/common/sensors.yaml
+++ b/src/openamber/common/sensors.yaml
@@ -17,6 +17,10 @@
   entity_category: diagnostic
   web_server: 
     sorting_group_id: diagnostic
+  filters:
+    - sliding_window_moving_average:
+        window_size: 60
+        send_every: 1
           
 - platform: uptime
   name: "Uptime"

--- a/src/openamber/controllers/constants.h
+++ b/src/openamber/controllers/constants.h
@@ -42,6 +42,9 @@ static const uint32_t BACKUP_HEATER_LOOKAHEAD_S = 2 * 60;
 static const uint32_t BACKUP_HEATER_OFF_SETTLE_TIME_S = 2 * 60;
 static const uint32_t DHW_BACKUP_HEATER_GRACE_PERIOD_S = 10 * 60;
 
+// Dhw
+static const uint32_t DHW_PUMP_TEMPERATURE_SETTLE_TIME_S = 2 * 60;
+
 
 // ============================================================================
 // TEMPERATURE CONSTANTS

--- a/src/openamber/ui/page_home.yaml
+++ b/src/openamber/ui/page_home.yaml
@@ -190,7 +190,34 @@ obj:
                     y: 2
                 - label:
                     id: header_outdoor
-                    text: "Buiten -.-°C"
+                    text: "Buiten -°C"
+                    text_color: 0x1F2933
+                    text_font: font_mdi_24
+
+          - obj:
+              id: water_mode_temperature_group
+              align: BOTTOM_RIGHT
+              x: 0
+              y: 0
+              width: SIZE_CONTENT
+              height: SIZE_CONTENT
+              pad_all: 0
+              bg_opa: 0%
+              border_opa: 0%
+              layout:
+                type: FLEX
+                flex_flow: COLUMN
+                flex_align_cross: END
+                pad_row: 2
+              widgets:
+                - label:
+                    id: water_mode_temperature_caption
+                    text: "Huidig / Doel"
+                    text_color: 0x1F2933
+                    text_font: font_mdi_24
+                - label:
+                    id: water_mode_temperature_values
+                    text: "-°C / -°C"
                     text_color: 0x1F2933
                     text_font: font_mdi_24
 

--- a/src/openamber/ui/ui_update_loop.yaml
+++ b/src/openamber/ui/ui_update_loop.yaml
@@ -162,6 +162,29 @@
         snprintf(buf, sizeof(buf), "Buiten %.1f°C", v);
         return std::string(buf);
 
+  - lvgl.label.update:
+      id: water_mode_temperature_values
+      text: !lambda |-
+        const std::string main_state = id(state_machine_state_main).state;
+        float current_temperature = NAN;
+        float target_temperature = NAN;
+
+        if (main_state == "DHW") {
+          current_temperature = id(dhw_temperature_tw_sensor).state;
+          target_temperature = id(current_dhw_setpoint_sensor).state;
+        } else if (main_state == "Heat/Cool") {
+          current_temperature = id(heat_cool_temperature_tc).state;
+          target_temperature = id(current_setpoint).state;
+        }
+
+        char buf[48];
+        if (isnan(current_temperature) || isnan(target_temperature)) {
+          snprintf(buf, sizeof(buf), "-°C / -°C");
+        } else {
+          snprintf(buf, sizeof(buf), "%.1f°C / %.1f°C", current_temperature, target_temperature);
+        }
+        return std::string(buf);
+
   - lvgl.widget.update:
       id: nav_status_heat_icon
       hidden: !lambda |-


### PR DESCRIPTION
This pull request introduces several improvements to the DHW logic to enhance temperature rate calculations.

* Introduced DHW_PUMP_TEMPERATURE_SETTLE_TIME_S to ensure heating logic is done when the temperature settles.
* Added DEFROSTING state to state machine to prevent unwanted behavior during defrosts.
* Replaced manual temperature rate calculation with sensor-based moving average to make it more reliable.
* Added current and target temperature to UI.