### PR TITLE
Implement P1 pump control

### DIFF
--- a/src/openamber/common/switches.yaml
+++ b/src/openamber/common/switches.yaml
@@ -1,4 +1,13 @@
 - platform: template
+  id: pump_p1_enabled
+  name: "Pomp P1 aanwezig"
+  optimistic: True
+  restore_mode: RESTORE_DEFAULT_OFF
+  entity_category: config
+  web_server: 
+    sorting_group_id: verwarmings_settings
+
+- platform: template
   id: legio_enabled_switch
   name: "Legionellapreventie"
   optimistic: True


### PR DESCRIPTION
Adds pump_p1_enabled setting which determines whether the P1 pump should be turned on and off.

Pump P1 will start whenever there is demand.
Stops P1 when defrost is active, starts again when defrost is finished.