### PR TITLE
Extend compressor operating frequency range during heating (30-90Hz)

### DIFF
--- a/src/openamber/common/numbers.yaml
+++ b/src/openamber/common/numbers.yaml
@@ -278,11 +278,90 @@
   modbus_controller_id: modbus_outside_unit
   id: outlet_temperature_outside
   internal: True
-  name: "CV-aanvoertemperatuur - Buiten"
   address: 2005
   register_type: holding
   value_type: S_WORD
   mode: box
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_1
+  internal: True
+  address: 3012
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_2
+  internal: True
+  address: 3013
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_3
+  internal: True
+  address: 3014
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_4
+  internal: True
+  address: 3015
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_5
+  internal: True
+  address: 3016
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_6
+  internal: True
+  address: 3017
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_7
+  internal: True
+  address: 3018
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_8
+  internal: True
+  address: 3019
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_9
+  internal: True
+  address: 3020
+  register_type: holding
+  value_type: S_WORD
+
+- platform: modbus_controller
+  modbus_controller_id: modbus_outside_unit
+  id: heating_frequency_index_10
+  internal: True
+  address: 3021
+  register_type: holding
+  value_type: S_WORD
 
 - platform: template
   name: "Pomp interval (minuten)"

--- a/src/openamber/controllers/openamber_component.h
+++ b/src/openamber/controllers/openamber_component.h
@@ -74,6 +74,7 @@ void OpenAmberComponent::update()
     {
       id(initialize_relay_switch).turn_on();
       id(pump_p0_relay_switch).turn_on();
+      WriteHeatingFrequencyTable();
       ESP_LOGI("amber", "Initialized heat pump controller");
       SetNextState(current_valve_position == ThreeWayValvePosition::DHW ? State::DHW_HEAT : State::HEAT_COOL);
       break;
@@ -201,6 +202,21 @@ ThreeWayValvePosition OpenAmberComponent::GetDesiredThreeWayValvePosition()
   
   // Otherwise use heating/cooling position
   return ThreeWayValvePosition::HEATING_COOLING;
+}
+
+void OpenAmberComponent::WriteHeatingFrequencyTable()
+{
+      // Patch heating frequency table to have more control in low load situations.
+      id(heating_frequency_index_1).publish_state(30);
+      id(heating_frequency_index_2).publish_state(36);
+      id(heating_frequency_index_3).publish_state(43);
+      id(heating_frequency_index_4).publish_state(49);
+      id(heating_frequency_index_5).publish_state(55);
+      id(heating_frequency_index_6).publish_state(61);
+      id(heating_frequency_index_7).publish_state(69);
+      id(heating_frequency_index_8).publish_state(74);
+      id(heating_frequency_index_9).publish_state(82);
+      id(heating_frequency_index_10).publish_state(90);
 }
 }  // namespace openamber
 }  // namespace esphome

--- a/src/openamber/openamber_component/openamber_component.h
+++ b/src/openamber/openamber_component/openamber_component.h
@@ -57,6 +57,7 @@ private:
   void ApplyWorkingMode();
   void SetNextState(State state);
   const char* StateToString(State state);
+  void WriteHeatingFrequencyTable();
 public:
   OpenAmberComponent();
   ~OpenAmberComponent();


### PR DESCRIPTION
The change in this PR will write the heating frequency table to use the following frequencies:
30, 36, 43, 49, 55, 61, 69, 74, 82, 90

This allows to save around 100W compared to lowest 36Hz mode before.