### PR TITLE
Fixed legionella not starting correctly in certain conditions

### DIFF
--- a/src/openamber/common/binary_sensors.yaml
+++ b/src/openamber/common/binary_sensors.yaml
@@ -59,9 +59,9 @@
         return false;
       }
 
-      if(!id(dhw_schedule_active_sensor).state)
+      if(!id(dhw_schedule_active_sensor).state && !id(dhw_legionella_run_active_sensor).state)
       {
-        return false;
+         return false;
       }
 
       return tw < setpoint;
@@ -74,6 +74,8 @@
   device_class: running
   web_server: 
     sorting_group_id: diagnostic
+  on_state:
+    - component.update: current_dhw_setpoint_sensor
 
 - platform: template
   name: "Warmtevraag"
@@ -173,6 +175,8 @@
            (!id(sg_ready_a_active_sensor).state && id(sg_ready_b_active_sensor).state);
   web_server: 
     sorting_group_id: diagnostic
+  on_state:
+    - component.update: current_dhw_setpoint_sensor
 
 - platform: template
   name: "SG-Ready maxboostmodus"
@@ -184,6 +188,8 @@
            (id(sg_ready_a_active_sensor).state && id(sg_ready_b_active_sensor).state);
   web_server: 
     sorting_group_id: diagnostic
+  on_state:
+    - component.update: current_dhw_setpoint_sensor
 
 - platform: modbus_controller
   modbus_controller_id: modbus_inside_unit

--- a/src/openamber/common/numbers.yaml
+++ b/src/openamber/common/numbers.yaml
@@ -179,6 +179,8 @@
   entity_category: config
   web_server: 
       sorting_group_id: dhw_settings
+  on_value:
+    - component.update: current_dhw_setpoint_sensor
 
 - platform: template
   id: dhw_restart_dhw_delta
@@ -439,6 +441,8 @@
   entity_category: config
   web_server: 
     sorting_group_id: dhw_settings
+  on_value:
+    - component.update: current_dhw_setpoint_sensor
 
 - platform: template
   id: sg_ready_heating_boost_temperature_number
@@ -469,3 +473,5 @@
   entity_category: config
   web_server: 
     sorting_group_id: dhw_settings
+  on_value:
+    - component.update: current_dhw_setpoint_sensor

--- a/src/openamber/common/sensors.yaml
+++ b/src/openamber/common/sensors.yaml
@@ -104,6 +104,7 @@
   name: "Huidig tapwater setpoint"
   unit_of_measurement: "°C"
   accuracy_decimals: 0
+  update_interval: never
   lambda: |-
     float setpoint = 0.0;
     if (id(dhw_legionella_run_active_sensor).state)

--- a/src/openamber/controllers/dhw_controller.h
+++ b/src/openamber/controllers/dhw_controller.h
@@ -499,7 +499,6 @@ public:
 
     if(id(dhw_legionella_run_active_sensor).state)
     {
-      ESP_LOGI("amber", "DHW legionella run active, allowing DHW start regardless of current temperature.");
       return true;
     }
 
@@ -544,7 +543,7 @@ public:
     }
     else if(id(dhw_legionella_run_active_sensor).state && !id(dhw_demand_active_sensor).state)
     {
-      ESP_LOGI("amber", "Legionella cycle completed, target temperature %.2f°C reached.", id(legio_target_temperature_number).state);
+      ESP_LOGI("amber", "Legionella cycle completed, target temperature %.2f°C reached, current temperature: %.2f°C, current setpoint: %.2f°C.", id(legio_target_temperature_number).state, id(dhw_temperature_tw_sensor).state, id(current_dhw_setpoint_sensor).state);
       id(dhw_legionella_run_active_sensor).publish_state(false);
     }
   }


### PR DESCRIPTION
Fixes that the current_dhw_setpoint_sensor is not instantly updated so the logic will still use the normal DHW target setpoint.

Fixes an issue where legionella run is not started when it is run outside of the configured schedule.