### PR TITLE
Prevent reboot due to offline mqtt broker

### DIFF
--- a/src/openamber/common/openamber.yaml
+++ b/src/openamber/common/openamber.yaml
@@ -82,6 +82,7 @@ mqtt:
   enable_on_boot: false
   username: openamber_write
   password: openamber
+  reboot_timeout: 0s
   discovery: false
   discover_ip: false
   discovery_retain: false


### PR DESCRIPTION
Today the mqtt broker was offline for a bit, causing OpenAmber to restart after a while.
`[31m2026-03-28 13:19:15.093 ERROR (MainThread) [homeassistant.components.esphome.manager] OpenAmber: [E][mqtt:419]: Can't connect; restarting[0m`

Adding reboot timeout of 0s to the mqtt broker should prevent this. The _api:_ component already has it. 