### PR TITLE
Assign shared modbus and reduce register counts

### DIFF
--- a/src/openamber/common/openamber.yaml
+++ b/src/openamber/common/openamber.yaml
@@ -250,10 +250,12 @@ time:
     timezone: "Europe/Amsterdam"
 
 modbus:
+  id: modbus_bus
   send_wait_time: 250ms
 
 modbus_controller:
 - id: modbus_outside_unit
+  modbus_id: modbus_bus
   address: 0x2
   update_interval: 30s
   command_throttle: 1000ms
@@ -269,6 +271,7 @@ modbus_controller:
           id(modbus_outside_is_online) = true;
       - logger.log: "Modbus outside unit ONLINE"
 - id: modbus_inside_unit
+  modbus_id: modbus_bus
   address: 0x0B
   update_interval: 30s
   command_throttle: 1000ms

--- a/src/openamber/common/sensors.yaml
+++ b/src/openamber/common/sensors.yaml
@@ -214,7 +214,6 @@
   state_class: measurement
   unit_of_measurement: °C   
   accuracy_decimals: 1
-  register_count: 16 # 1199 - 1214
   filters:
     - offset: -3000
     - multiply: 0.01
@@ -381,7 +380,6 @@
   unit_of_measurement: "V"
   accuracy_decimals: 0
   state_class: "measurement"
-  register_count: 33 # 2100-2132
   entity_category: diagnostic
   web_server: 
     sorting_group_id: diagnostic

--- a/src/openamber/common/sensors.yaml
+++ b/src/openamber/common/sensors.yaml
@@ -214,6 +214,7 @@
   state_class: measurement
   unit_of_measurement: °C   
   accuracy_decimals: 1
+  register_count: 10 # 1199 - 1208
   filters:
     - offset: -3000
     - multiply: 0.01
@@ -380,6 +381,7 @@
   unit_of_measurement: "V"
   accuracy_decimals: 0
   state_class: "measurement"
+  register_count: 33 # 2100-2132
   entity_category: diagnostic
   web_server: 
     sorting_group_id: diagnostic


### PR DESCRIPTION
Experienced another crash and followed the backtrace:

`0x4037c614: panic_abort at /Users/user/.platformio/packages/framework-espidf/components/esp_system/panic.c:489
0x4037c611: panic_abort at /Users/user/.platformio/packages/framework-espidf/components/esp_system/panic.c:477
0x4037c5d9: esp_system_abort at /Users/user/.platformio/packages/framework-espidf/components/esp_system/port/esp_system_chip.c:87
0x40380b36: abort at /Users/user/.platformio/packages/framework-espidf/components/newlib/src/abort.c:38
0x4210826a: __wrap___cxa_allocate_exception at /Users/user/.platformio/packages/framework-espidf/components/cxx/cxx_exception_stubs.cpp:184
0x42100ce9: operator new(unsigned int) at /builds/idf/crosstool-NG/.build/xtensa-esp-elf/src/gcc/libstdc++-v3/libsupc++/new_op.cc:54
0x420142be: std::__new_allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > >::allocate(unsigned int, void const*) at /Users/user/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/new_allocator.h:151
 (inlined by) std::allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > >::allocate(unsigned int) at /Users/user/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/allocator.h:196
 (inlined by) std::allocator_traits<std::allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > > >::allocate(std::allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > >&, unsigned int) at /Users/user/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/alloc_traits.h:478
 (inlined by) std::_Deque_base<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >, std::allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > > >::_M_allocate_node() at /Users/user/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_deque.h:583
 (inlined by) void std::deque<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >, std::allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > > >::_M_push_back_aux<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > >(std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >&&) at /Users/user/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/deque.tcc:497
 (inlined by) std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >& std::deque<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >, std::allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > > >::emplace_back<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > >(std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >&&) at /Users/user/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/deque.tcc:176
 (inlined by) std::deque<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >, std::allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > > >::push_back(std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >&&) at /Users/user/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_deque.h:1554
 (inlined by) std::queue<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >, std::deque<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >, std::allocator<std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> > > > >::push(std::unique_ptr<esphome::modbus_controller::ModbusCommandItem, std::default_delete<esphome::modbus_controller::ModbusCommandItem> >&&) at /Users/user/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_queue.h:289
 (inlined by) esphome::modbus_controller::ModbusController::on_modbus_data(std::vector<unsigned char, std::allocator<unsigned char> > const&) at ../openamber/src/.esphome/build/openamber/src/esphome/components/modbus_controller/modbus_controller.cpp:84
0x4201437c: non-virtual thunk to esphome::modbus_controller::ModbusController::on_modbus_data(std::vector<unsigned char, std::allocator<unsigned char> > const&) at ../openamber/src/.esphome/build/openamber/src/esphome/components/modbus_controller/modbus_controller.h:483
0x4201277d: esphome::modbus::Modbus::parse_modbus_byte_(unsigned char) at ../openamber/src/.esphome/build/openamber/src/esphome/components/modbus/modbus.cpp:260
0x420127d9: esphome::modbus::Modbus::receive_and_parse_modbus_bytes_() at ../openamber/src/.esphome/build/openamber/src/esphome/components/modbus/modbus.cpp:112
0x420127fd: esphome::modbus::Modbus::loop() at ../openamber/src/.esphome/build/openamber/src/esphome/components/modbus/modbus.cpp:42
0x4202a2dc: esphome::Application::loop() at ../openamber/src/.esphome/build/openamber/src/esphome/core/application.cpp:184
0x4203339a: loop() at ../openamber/src/.esphome/build/openamber/src/openamber/ui/ui_update_loop.yaml:131
0x42009706: esphome::loop_task(void*) at ../openamber/src/.esphome/build/openamber/src/esphome/components/esp32/core.cpp:71 (discriminator 1)`

Proposed changes:
-  Before each controller might have tried to create its own internal bus or use a default, which could lead to duplicate commands or more memory usage than expected.
-  Remove unwanted register_count when not needed, which could lead to modbus commands to queue up