### PR TITLE
Fixed pid controller target not updated correctly

### DIFF
--- a/src/openamber/common/numbers.yaml
+++ b/src/openamber/common/numbers.yaml
@@ -180,7 +180,8 @@
   web_server: 
       sorting_group_id: dhw_settings
   on_value:
-    - component.update: current_dhw_setpoint_sensor
+    then:
+      - component.update: current_dhw_setpoint_sensor
 
 - platform: template
   id: dhw_restart_dhw_delta

--- a/src/openamber/common/numbers.yaml
+++ b/src/openamber/common/numbers.yaml
@@ -610,7 +610,8 @@
   web_server: 
     sorting_group_id: dhw_settings
   on_value:
-    - component.update: current_dhw_setpoint_sensor
+    then:
+      - component.update: current_dhw_setpoint_sensor
 
 - platform: template
   id: sg_ready_heating_boost_temperature_number
@@ -627,7 +628,8 @@
   web_server: 
     sorting_group_id: heating_settings
   on_value:
-    - component.update: current_setpoint
+    then:
+      - component.update: current_setpoint
 
 - platform: template
   id: sg_ready_dhw_boost_temperature_number
@@ -644,4 +646,5 @@
   web_server: 
     sorting_group_id: dhw_settings
   on_value:
-    - component.update: current_dhw_setpoint_sensor
+    then:
+      - component.update: current_dhw_setpoint_sensor

--- a/src/openamber/common/sensors.yaml
+++ b/src/openamber/common/sensors.yaml
@@ -123,12 +123,13 @@
 
     return setpoint;
   on_value:
-    - lambda: |-
-        auto working_mode = id(working_mode_switch).active_index();
-        auto climate = working_mode.has_value() && working_mode.value() == WORKING_MODE_COOLING ? id(pid_cool_temperature_control) : id(pid_heat_temperature_control);
-        auto call = climate->make_call();
-        call.set_target_temperature(x);
-        call.perform();
+    then:
+      - lambda: |-
+          auto working_mode = id(working_mode_switch).active_index();
+          auto climate = working_mode.has_value() && working_mode.value() == WORKING_MODE_COOLING ? id(pid_cool_temperature_control) : id(pid_heat_temperature_control);
+          auto call = climate->make_call();
+          call.set_target_temperature(x);
+          call.perform();
   web_server: 
     sorting_group_id: overview
 


### PR DESCRIPTION
on_value automations were not merged properly by using inconsistent syntax, causing on_value automations to be overwritten.