### PR TITLE
Fixed that compressor could stop after an oil return cycle was completed.

### DIFF
--- a/src/openamber/common/binary_sensors.yaml
+++ b/src/openamber/common/binary_sensors.yaml
@@ -449,6 +449,14 @@
   web_server: 
     sorting_group_id: error_codes
 
+- platform: template
+  id: oil_return_cycle_active_settled
+  internal: True
+  filters:
+    - delayed_off: 300s
+  lambda: |-
+    return id(oil_return_cycle_active).state;
+
 - platform: modbus_controller
   modbus_controller_id: modbus_outside_unit
   name: "Hogedrukbeveiliging (P05)"

--- a/src/openamber/controllers/heat_cool_controller.h
+++ b/src/openamber/controllers/heat_cool_controller.h
@@ -383,7 +383,7 @@ public:
 
     if (overshoot >= stop_delta)
     {
-      if (id(oil_return_cycle_active).state)
+      if (id(oil_return_cycle_active_settled).state)
       {
         ESP_LOGI("amber", "Not stopping compressor because oil return cycle is active.");
         return false;


### PR DESCRIPTION
We would already ignore stop conditions during an oil return cycle but we were not waiting for the temperature to settle after the cycle. Now a settle time of 5 minutes is implemented.