### PR TITLE
Add PR build pipeline

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -11,7 +11,7 @@ on:
         type: string
       esphome-version:
         required: false
-        default: '2026.6.2'
+        default: '2026.6.3'
         type: string
       release-summary:
         required: false

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -11,7 +11,7 @@ on:
         type: string
       esphome-version:
         required: false
-        default: '2026.6.4'
+        default: '2026.6.2'
         type: string
       release-summary:
         required: false

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -9,6 +9,10 @@ on:
       combined-name:
         required: true
         type: string
+      esphome-version:
+        required: false
+        default: '2026.6.4'
+        type: string
       release-summary:
         required: false
         default: ''
@@ -28,7 +32,7 @@ jobs:
     uses: esphome/workflows/.github/workflows/build.yml@3c4e8446aa1029f1c346a482034b3ee1489077ca  # 2026.4.0
     with:
       files: ${{ inputs.files }}
-      esphome-version: 2026.6.2
+      esphome-version: ${{ inputs.esphome-version }}
       combined-name: ${{ inputs.combined-name }}
       release-summary: ${{ inputs.release-summary }}
       release-url: ${{ inputs.release-url }}

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,0 +1,35 @@
+name: Build firmware (shared)
+
+on:
+  workflow_call:
+    inputs:
+      files:
+        required: true
+        type: string
+      combined-name:
+        required: true
+        type: string
+      release-summary:
+        required: false
+        default: ''
+        type: string
+      release-url:
+        required: false
+        default: ''
+        type: string
+      release-version:
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  build-firmware:
+    name: Build Firmware
+    uses: esphome/workflows/.github/workflows/build.yml@3c4e8446aa1029f1c346a482034b3ee1489077ca  # 2026.4.0
+    with:
+      files: ${{ inputs.files }}
+      esphome-version: 2026.6.2
+      combined-name: ${{ inputs.combined-name }}
+      release-summary: ${{ inputs.release-summary }}
+      release-url: ${{ inputs.release-url }}
+      release-version: ${{ inputs.release-version }}

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -28,7 +28,7 @@ jobs:
     uses: esphome/workflows/.github/workflows/build.yml@3c4e8446aa1029f1c346a482034b3ee1489077ca  # 2026.4.0
     with:
       files: ${{ inputs.files }}
-      esphome-version: 2026.6.2
+      esphome-version: 2026.6.4
       combined-name: ${{ inputs.combined-name }}
       release-summary: ${{ inputs.release-summary }}
       release-url: ${{ inputs.release-url }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/build-firmware.yml
     with:
       files: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,10 +2,14 @@ name: Build firmware on PR publish
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - src/**
       - .github/workflows/**
+
+concurrency:
+  group: build-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build-firmware:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,18 @@
+name: Build firmware on PR publish
+
+on:
+  pull_request:
+    types: [ready_for_review]
+    paths:
+      - src/**
+      - .github/workflows/**
+
+jobs:
+  build-firmware:
+    name: Build Firmware
+    uses: ./.github/workflows/build-firmware.yml
+    with:
+      files: |
+        src/openamber-leejow.yaml
+        src/openamber-waveshare-display.yaml
+      combined-name: openamber-pr-validation

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,12 +10,11 @@ permissions:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@3c4e8446aa1029f1c346a482034b3ee1489077ca  # 2026.4.0
+    uses: ./.github/workflows/build-firmware.yml
     with:
       files: |
         src/openamber-leejow.yaml
         src/openamber-waveshare-display.yaml
-      esphome-version: 2026.6.2
       combined-name: openamber
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}

--- a/src/openamber-waveshare-display.yaml
+++ b/src/openamber-waveshare-display.yaml
@@ -63,6 +63,13 @@ display:
     model: WAVESHARE-5-1024X600
     id: my_display
     auto_clear_enabled: false
+    dimensions:
+      width: 1024
+      height: 600
+      offset_width: 0
+      offset_height: 0
+      pad_width: 0
+      pad_height: 0
 
 output:
   - platform: ledc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / CI Improvements**
  * Added a reusable **“Build firmware (shared)”** workflow to standardize firmware builds, including configurable firmware file lists and optional release metadata.
  * Introduced pull-request firmware validation that runs only when relevant firmware/config or workflow files change, with per-PR concurrency that cancels in-progress runs.
  * Updated release firmware builds to use the new shared local workflow for a more consistent build setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->