### PR TITLE
Add DHW backup heater delay setting

### DIFF
--- a/src/openamber/common/numbers.yaml
+++ b/src/openamber/common/numbers.yaml
@@ -264,6 +264,21 @@
     sorting_group_id: dhw_settings
 
 - platform: template
+  id: dhw_backup_min_avg_rate_delay_minutes
+  name: "Tapwater backup heater vertraging"
+  unit_of_measurement: "min"
+  device_class: "duration"
+  min_value: 0
+  max_value: 60
+  step: 1
+  initial_value: 5
+  optimistic: true
+  restore_value: true
+  entity_category: config
+  web_server:
+    sorting_group_id: dhw_settings
+
+- platform: template
   id: backup_heater_degmin_threshold
   name: "Backup element graadminuten"
   unit_of_measurement: "°C·min"

--- a/src/openamber/controllers/base_controller.h
+++ b/src/openamber/controllers/base_controller.h
@@ -88,7 +88,6 @@ protected:
   void TurnOnBackupHeater()
   {
     backup_heater_start_time_ms_ = App.get_loop_component_start_time();
-    heating_rate_below_min_since_ms_ = 0;
     if(id(backup_heating_mode).active_index().value() == 0)
     {      
       id(backup_heater_relay).turn_on();

--- a/src/openamber/controllers/base_controller.h
+++ b/src/openamber/controllers/base_controller.h
@@ -88,6 +88,7 @@ protected:
   void TurnOnBackupHeater()
   {
     backup_heater_start_time_ms_ = App.get_loop_component_start_time();
+    heating_rate_below_min_since_ms_ = 0;
     if(id(backup_heating_mode).active_index().value() == 0)
     {      
       id(backup_heater_relay).turn_on();

--- a/src/openamber/controllers/dhw_controller.h
+++ b/src/openamber/controllers/dhw_controller.h
@@ -43,6 +43,7 @@ class DHWController : public BaseController<DHWState>
 {
 private:
   uint32_t last_rate_measured_time_ = 0;
+  uint32_t heating_rate_below_min_since_ms_ = 0;
   float last_temperature_rate_ = 0.0f;
   float last_measured_temperature_ = 0.0f;
   float dhw_pump_settled_time_ = 0.0f;
@@ -117,6 +118,7 @@ private:
     ESP_LOGI("amber", "Stopping DHW pump.");
     id(dhw_pump_relay_switch).turn_off();
     dhw_pump_settled_time_ = 0.0f;
+    heating_rate_below_min_since_ms_ = 0;
   }
 
   bool IsPredictedTemperatureAboveTarget()
@@ -191,22 +193,46 @@ private:
 
   bool IsHeatingSlowerThanMinimumAverageRate()
   {  
+    uint32_t now = App.get_loop_component_start_time();
+
     // Don't enable backup heater based when DHW pump is not started yet.
     if(!id(dhw_pump_relay_switch).state)
     {
+      heating_rate_below_min_since_ms_ = 0;
       return false;
     }
 
     // Start calculations after grace period to let the average sensor gather enough data.
-    if(App.get_loop_component_start_time() - dhw_pump_settled_time_ < DHW_BACKUP_HEATER_GRACE_PERIOD_S * 1000UL)
+    if(now - dhw_pump_settled_time_ < DHW_BACKUP_HEATER_GRACE_PERIOD_S * 1000UL)
     {
+      heating_rate_below_min_since_ms_ = 0;
       return false;
     }
   
     float min_avg_rate = id(dhw_backup_min_avg_rate).state;
-    if (id(dhw_backup_current_avg_rate_sensor).state < min_avg_rate && min_avg_rate > 0.0f)
+    if (min_avg_rate <= 0.0f)
     {
-      ESP_LOGI("amber", "DHW backup enable: avg_rate=%.3f°C/min < min=%.3f°C/min", id(dhw_backup_current_avg_rate_sensor).state, min_avg_rate);
+      heating_rate_below_min_since_ms_ = 0;
+      return false;
+    }
+
+    float current_avg_rate = id(dhw_backup_current_avg_rate_sensor).state;
+    if (current_avg_rate >= min_avg_rate)
+    {
+      heating_rate_below_min_since_ms_ = 0;
+      return false;
+    }
+
+    if (heating_rate_below_min_since_ms_ == 0)
+    {
+      heating_rate_below_min_since_ms_ = now;
+      ESP_LOGI("amber", "DHW backup delay started: avg_rate=%.3f C/min < min=%.3f C/min", current_avg_rate, min_avg_rate);
+    }
+
+    uint32_t required_duration_ms = static_cast<uint32_t>(id(dhw_backup_min_avg_rate_delay_minutes).state * 60000.0f);
+    if (now - heating_rate_below_min_since_ms_ >= required_duration_ms)
+    {
+      ESP_LOGI("amber", "DHW backup enable: avg_rate=%.3f C/min < min=%.3f C/min for %.1f min", current_avg_rate, min_avg_rate, id(dhw_backup_min_avg_rate_delay_minutes).state);
       return true;
     }
 
@@ -355,6 +381,7 @@ public:
 
         if (id(defrost_active_sensor).state)
         {
+          heating_rate_below_min_since_ms_ = 0;
           SetNextState(DHWState::DEFROSTING);
           break;
         }
@@ -385,6 +412,7 @@ public:
         if(IsHeatingSlowerThanMinimumAverageRate())
         {
           ESP_LOGI("amber", "Enabling backup heater");
+          heating_rate_below_min_since_ms_ = 0;
           TurnOnBackupHeater();
           SetNextState(DHWState::WAIT_BACKUP_HEATER_RUNNING);
           break;
@@ -413,6 +441,7 @@ public:
         last_measured_temperature_ = id(dhw_temperature_tw_sensor).state;
         last_rate_measured_time_ = now;
         dhw_pump_settled_time_ = now;
+        heating_rate_below_min_since_ms_ = 0;
         SetNextState(id(emergency_mode_enabled).state ? DHWState::BACKUP_HEATER_RUNNING : DHWState::COMPRESSOR_RUNNING);
         break;
 

--- a/src/openamber/controllers/dhw_controller.h
+++ b/src/openamber/controllers/dhw_controller.h
@@ -381,7 +381,6 @@ public:
 
         if (id(defrost_active_sensor).state)
         {
-          heating_rate_below_min_since_ms_ = 0;
           SetNextState(DHWState::DEFROSTING);
           break;
         }
@@ -412,7 +411,6 @@ public:
         if(IsHeatingSlowerThanMinimumAverageRate())
         {
           ESP_LOGI("amber", "Enabling backup heater");
-          heating_rate_below_min_since_ms_ = 0;
           TurnOnBackupHeater();
           SetNextState(DHWState::WAIT_BACKUP_HEATER_RUNNING);
           break;

--- a/src/openamber/controllers/dhw_controller.h
+++ b/src/openamber/controllers/dhw_controller.h
@@ -339,6 +339,7 @@ public:
         {
           ESP_LOGW("amber", "Emergency mode enabled, not starting compressor but switching on backup heater");
           TurnOnBackupHeater();
+          heating_rate_below_min_since_ms_ = 0;
           SetNextState(DHWState::WAIT_BACKUP_HEATER_RUNNING);
         }
         else
@@ -404,6 +405,7 @@ public:
         {
           ESP_LOGI("amber", "Enabling backup heater (SG Ready max boost active)");
           TurnOnBackupHeater();
+          heating_rate_below_min_since_ms_ = 0;
           SetNextState(DHWState::WAIT_BACKUP_HEATER_RUNNING);
           break;
         }
@@ -412,6 +414,7 @@ public:
         {
           ESP_LOGI("amber", "Enabling backup heater");
           TurnOnBackupHeater();
+          heating_rate_below_min_since_ms_ = 0;
           SetNextState(DHWState::WAIT_BACKUP_HEATER_RUNNING);
           break;
         }

--- a/src/openamber/ui/bindings/number_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/number_ui_bindings.yaml
@@ -409,6 +409,15 @@
             format: "%.2f °C/min"
             args: ['x']
 
+- id: !extend dhw_backup_min_avg_rate_delay_minutes
+  on_value:
+    then:
+      - lvgl.label.update:
+          id: set_dhw_rate_delay_val
+          text:
+            format: "%.0f min"
+            args: ['x']
+
 # ── Legionella ──
 - id: !extend legio_repeat_days_number
   on_value:

--- a/src/openamber/ui/bindings/script_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/script_ui_bindings.yaml
@@ -534,6 +534,49 @@
                       - lvgl.label.update: { id: dhw_stab_legionella_lbl, text_color: 0xFFFFFF }
                       - script.execute: update_legio_ui
 
+- id: bijverwarmen_select_tab
+  mode: restart
+  parameters:
+    tab_index: int
+  then:
+    - if:
+        condition:
+          lambda: 'return tab_index == 0;'
+        then:
+          - lvgl.widget.show: { id: panel_bijverwarmen_page_algemeen }
+          - lvgl.widget.hide: { id: panel_bijverwarmen_page_verwarmen }
+          - lvgl.widget.hide: { id: panel_bijverwarmen_page_tapwater }
+          - lvgl.widget.update: { id: bijverwarmen_stab_algemeen, bg_color: 0x1F3B68 }
+          - lvgl.label.update: { id: bijverwarmen_stab_algemeen_lbl, text_color: 0xFFFFFF }
+          - lvgl.widget.update: { id: bijverwarmen_stab_verwarmen, bg_color: 0xCBD5E1 }
+          - lvgl.label.update: { id: bijverwarmen_stab_verwarmen_lbl, text_color: 0x4B5563 }
+          - lvgl.widget.update: { id: bijverwarmen_stab_tapwater, bg_color: 0xCBD5E1 }
+          - lvgl.label.update: { id: bijverwarmen_stab_tapwater_lbl, text_color: 0x4B5563 }
+        else:
+          - if:
+              condition:
+                lambda: 'return tab_index == 1;'
+              then:
+                - lvgl.widget.hide: { id: panel_bijverwarmen_page_algemeen }
+                - lvgl.widget.show: { id: panel_bijverwarmen_page_verwarmen }
+                - lvgl.widget.hide: { id: panel_bijverwarmen_page_tapwater }
+                - lvgl.widget.update: { id: bijverwarmen_stab_algemeen, bg_color: 0xCBD5E1 }
+                - lvgl.label.update: { id: bijverwarmen_stab_algemeen_lbl, text_color: 0x4B5563 }
+                - lvgl.widget.update: { id: bijverwarmen_stab_verwarmen, bg_color: 0x1F3B68 }
+                - lvgl.label.update: { id: bijverwarmen_stab_verwarmen_lbl, text_color: 0xFFFFFF }
+                - lvgl.widget.update: { id: bijverwarmen_stab_tapwater, bg_color: 0xCBD5E1 }
+                - lvgl.label.update: { id: bijverwarmen_stab_tapwater_lbl, text_color: 0x4B5563 }
+              else:
+                - lvgl.widget.hide: { id: panel_bijverwarmen_page_algemeen }
+                - lvgl.widget.hide: { id: panel_bijverwarmen_page_verwarmen }
+                - lvgl.widget.show: { id: panel_bijverwarmen_page_tapwater }
+                - lvgl.widget.update: { id: bijverwarmen_stab_algemeen, bg_color: 0xCBD5E1 }
+                - lvgl.label.update: { id: bijverwarmen_stab_algemeen_lbl, text_color: 0x4B5563 }
+                - lvgl.widget.update: { id: bijverwarmen_stab_verwarmen, bg_color: 0xCBD5E1 }
+                - lvgl.label.update: { id: bijverwarmen_stab_verwarmen_lbl, text_color: 0x4B5563 }
+                - lvgl.widget.update: { id: bijverwarmen_stab_tapwater, bg_color: 0x1F3B68 }
+                - lvgl.label.update: { id: bijverwarmen_stab_tapwater_lbl, text_color: 0xFFFFFF }
+
 - id: update_advanced_settings_ui
   mode: restart
   then:

--- a/src/openamber/ui/settings/page_settings_sidebar.yaml
+++ b/src/openamber/ui/settings/page_settings_sidebar.yaml
@@ -343,6 +343,9 @@ obj:
             - lvgl.widget.hide: { id: panel_cooling }
             - lvgl.widget.hide: { id: panel_dhw }
             - lvgl.widget.show: { id: panel_bijverwarmen }
+            - script.execute:
+                id: bijverwarmen_select_tab
+                tab_index: 0
             - lvgl.widget.hide: { id: panel_smartgrid }
             - lvgl.widget.hide: { id: panel_wifi }
             - lvgl.widget.hide: { id: panel_thermostat }

--- a/src/openamber/ui/settings/page_settings_tab_bijverwarmen.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_bijverwarmen.yaml
@@ -1,237 +1,157 @@
 ﻿# Panel: Bijverwarmen
 # ------------------------------------------------------------
 obj:
-    id: panel_bijverwarmen
-    width: 100%
-    height: 100%
-    hidden: true
-    bg_opa: 0%
-    border_opa: 0%
-    pad_left: 4
-    pad_right: 4
-    pad_top: 4
-    pad_bottom: 4
-    scrollbar_mode: "OFF"
-    scrollable: true
-    layout:
-      type: FLEX
-      flex_flow: COLUMN
-      flex_align_main: START
-      flex_align_cross: STRETCH
-      pad_row: 6
-      
-    widgets:
-      - obj:
-          width: 100%
-          height: SIZE_CONTENT
-          bg_opa: 0%
-          border_opa: 0%
-          pad_all: 6
-          widgets:
-            - label: { text: "Backup element", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
-            - label: { text: "Extern is voor Hybride opstellingen", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
-            - dropdown:
-                id: set_backup_heating_mode_dd
-                symbol: "\U000F0140"
-                width: 320
-                align: TOP_RIGHT
-                y: 0
-                options:
-                  - "Intern verwarmingselement"
-                  - "Externe backup verwarming"
-                text_font: font_text_20
-                dropdown_list:
-                  text_font: font_text_20
-                on_value:
-                  then:
-                    - lambda: |-
-                        auto val = lv_dropdown_get_selected(id(set_backup_heating_mode_dd)->obj);
-                        if (val == 0) id(backup_heating_mode).make_call().set_option("Intern verwarmingselement").perform();
-                        else id(backup_heating_mode).make_call().set_option("Externe backup verwarming").perform();
+  id: panel_bijverwarmen
+  width: 100%
+  height: 100%
+  hidden: true
+  bg_opa: 0%
+  border_opa: 0%
+  pad_left: 4
+  pad_right: 4
+  pad_top: 4
+  pad_bottom: 4
+  scrollbar_mode: "OFF"
+  scrollable: true
+  layout:
+    type: FLEX
+    flex_flow: COLUMN
+    flex_align_main: START
+    flex_align_cross: STRETCH
+    pad_row: 4
 
-      - obj:
-          width: 100%
-          height: SIZE_CONTENT
-          bg_opa: 0%
-          border_opa: 0%
-          pad_all: 6
-          widgets:
-            - label: { text: "Boosttemperatuur bij ontdooien", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
-            - label: { text: "Buitentemperatuur voor backup bij ontdooien", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
-            - obj:
-                width: SIZE_CONTENT
-                height: SIZE_CONTENT
-                align: TOP_RIGHT
-                bg_opa: 0%
-                border_opa: 0%
-                pad_all: 0
-                layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
-                widgets:
-                  - obj:
-                      width: 40
-                      height: 40
-                      bg_color: 0x1F3B68
-                      bg_opa: 100%
-                      radius: 10
-                      border_opa: 0%
-                      scrollbar_mode: "OFF"
-                      scrollable: false
-                      on_click:
-                        - number.decrement: defrost_backup_heater_boost_temperature_sensor
-                      widgets:
-                        - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
-                  - label: { id: set_defrost_boost_val, text: "-3°C", text_color: 0x1F2933, text_font: font_text_24 }
-                  - obj:
-                      width: 40
-                      height: 40
-                      bg_color: 0x1F3B68
-                      bg_opa: 100%
-                      radius: 10
-                      border_opa: 0%
-                      scrollbar_mode: "OFF"
-                      scrollable: false
-                      on_click:
-                        - number.increment: defrost_backup_heater_boost_temperature_sensor
-                      widgets:
-                        - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
-      
-      - obj:
-          width: 100%
-          height: SIZE_CONTENT
-          bg_opa: 0%
-          border_opa: 0%
-          pad_all: 6
-          widgets:
-            - label: { text: "Backup °min drempel (verwarmen)", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
-            - label: { text: "Graadminuten drempel voor backup element tijdens verwarmen", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
-            - obj:
-                width: SIZE_CONTENT
-                height: SIZE_CONTENT
-                align: TOP_RIGHT
-                bg_opa: 0%
-                border_opa: 0%
-                pad_all: 0
-                layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
-                widgets:
-                  - obj:
-                      width: 40
-                      height: 40
-                      bg_color: 0x1F3B68
-                      bg_opa: 100%
-                      radius: 10
-                      border_opa: 0%
-                      scrollbar_mode: "OFF"
-                      scrollable: false
-                      on_click:
-                        - number.decrement: backup_heater_degmin_threshold
-                      widgets:
-                        - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
-                  - label: { id: set_degmin_val, text: "40 °C·min", text_color: 0x1F2933, text_font: font_text_24 }
-                  - obj:
-                      width: 40
-                      height: 40
-                      bg_color: 0x1F3B68
-                      bg_opa: 100%
-                      radius: 10
-                      border_opa: 0%
-                      scrollbar_mode: "OFF"
-                      scrollable: false
-                      on_click:
-                        - number.increment: backup_heater_degmin_threshold
-                      widgets:
-                        - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
-      
-      - obj:
-          width: 100%
-          height: SIZE_CONTENT
-          bg_opa: 0%
-          border_opa: 0%
-          pad_all: 6
-          widgets:
-            - label: { text: "Min. verwarmsnelheid (Tapwater)", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
-            - label: { text: "Minimale Tapwater-verwarmsnelheid; lager schakelt backup in", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
-            - obj:
-                width: SIZE_CONTENT
-                height: SIZE_CONTENT
-                align: TOP_RIGHT
-                bg_opa: 0%
-                border_opa: 0%
-                pad_all: 0
-                layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
-                widgets:
-                  - obj:
-                      width: 40
-                      height: 40
-                      bg_color: 0x1F3B68
-                      bg_opa: 100%
-                      radius: 10
-                      border_opa: 0%
-                      scrollbar_mode: "OFF"
-                      scrollable: false
-                      on_click:
-                        - number.decrement: dhw_backup_min_avg_rate
-                      widgets:
-                        - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
-                  - label: { id: set_dhw_rate_val, text: "0.12 °C/min", text_color: 0x1F2933, text_font: font_text_24 }
-                  - obj:
-                      width: 40
-                      height: 40
-                      bg_color: 0x1F3B68
-                      bg_opa: 100%
-                      radius: 10
-                      border_opa: 0%
-                      scrollbar_mode: "OFF"
-                      scrollable: false
-                      on_click:
-                        - number.increment: dhw_backup_min_avg_rate
-                      widgets:
-                        - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+  widgets:
+    - obj:
+        id: panel_bijverwarmen_tab_bar
+        width: 100%
+        height: 40
+        bg_opa: 0%
+        border_opa: 0%
+        pad_all: 0
+        scrollbar_mode: "OFF"
+        scrollable: false
+        layout:
+          type: FLEX
+          flex_flow: ROW
+          flex_align_main: START
+          flex_align_cross: CENTER
+          pad_column: 6
+        widgets:
+          - obj:
+              id: bijverwarmen_stab_algemeen
+              width: SIZE_CONTENT
+              height: 34
+              bg_color: 0x1F3B68
+              bg_opa: 100%
+              radius: 8
+              border_opa: 0%
+              pad_left: 12
+              pad_right: 12
+              pad_top: 4
+              pad_bottom: 4
+              scrollbar_mode: "OFF"
+              scrollable: false
+              on_click:
+                - script.execute:
+                    id: bijverwarmen_select_tab
+                    tab_index: 0
+              widgets:
+                - label: { id: bijverwarmen_stab_algemeen_lbl, text: "Algemeen", text_color: 0xFFFFFF, text_font: font_text_20, align: CENTER }
 
-      - obj:
-          width: 100%
-          height: SIZE_CONTENT
-          bg_opa: 0%
-          border_opa: 0%
-          pad_all: 6
-          widgets:
-            - label: { text: "Backupvertraging (Tapwater)", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
-            - label: { text: "Tijd onder minimale verwarmsnelheid voordat backup inschakelt", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
-            - obj:
-                width: SIZE_CONTENT
-                height: SIZE_CONTENT
-                align: TOP_RIGHT
-                bg_opa: 0%
-                border_opa: 0%
-                pad_all: 0
-                layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
-                widgets:
-                  - obj:
-                      width: 40
-                      height: 40
-                      bg_color: 0x1F3B68
-                      bg_opa: 100%
-                      radius: 10
-                      border_opa: 0%
-                      scrollbar_mode: "OFF"
-                      scrollable: false
-                      on_click:
-                        - number.decrement: dhw_backup_min_avg_rate_delay_minutes
-                      widgets:
-                        - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
-                  - label: { id: set_dhw_rate_delay_val, text: "5 min", text_color: 0x1F2933, text_font: font_text_24 }
-                  - obj:
-                      width: 40
-                      height: 40
-                      bg_color: 0x1F3B68
-                      bg_opa: 100%
-                      radius: 10
-                      border_opa: 0%
-                      scrollbar_mode: "OFF"
-                      scrollable: false
-                      on_click:
-                        - number.increment: dhw_backup_min_avg_rate_delay_minutes
-                      widgets:
-                        - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+          - obj:
+              id: bijverwarmen_stab_verwarmen
+              width: SIZE_CONTENT
+              height: 34
+              bg_color: 0xCBD5E1
+              bg_opa: 100%
+              radius: 8
+              border_opa: 0%
+              pad_left: 12
+              pad_right: 12
+              pad_top: 4
+              pad_bottom: 4
+              scrollbar_mode: "OFF"
+              scrollable: false
+              on_click:
+                - script.execute:
+                    id: bijverwarmen_select_tab
+                    tab_index: 1
+              widgets:
+                - label: { id: bijverwarmen_stab_verwarmen_lbl, text: "Verwarmen", text_color: 0x4B5563, text_font: font_text_20, align: CENTER }
+
+          - obj:
+              id: bijverwarmen_stab_tapwater
+              width: SIZE_CONTENT
+              height: 34
+              bg_color: 0xCBD5E1
+              bg_opa: 100%
+              radius: 8
+              border_opa: 0%
+              pad_left: 12
+              pad_right: 12
+              pad_top: 4
+              pad_bottom: 4
+              scrollbar_mode: "OFF"
+              scrollable: false
+              on_click:
+                - script.execute:
+                    id: bijverwarmen_select_tab
+                    tab_index: 2
+              widgets:
+                - label: { id: bijverwarmen_stab_tapwater_lbl, text: "Tapwater", text_color: 0x4B5563, text_font: font_text_20, align: CENTER }
+
+    - obj:
+        id: panel_bijverwarmen_page_algemeen
+        width: 100%
+        height: SIZE_CONTENT
+        bg_opa: 0%
+        border_opa: 0%
+        pad_all: 0
+        scrollbar_mode: "OFF"
+        scrollable: false
+        layout:
+          type: FLEX
+          flex_flow: COLUMN
+          flex_align_main: START
+          flex_align_cross: STRETCH
+          pad_row: 6
+        widgets: !include page_settings_tab_bijverwarmen_algemeen_content.yaml
+
+    - obj:
+        id: panel_bijverwarmen_page_verwarmen
+        hidden: true
+        width: 100%
+        height: SIZE_CONTENT
+        bg_opa: 0%
+        border_opa: 0%
+        pad_all: 0
+        scrollbar_mode: "OFF"
+        scrollable: false
+        layout:
+          type: FLEX
+          flex_flow: COLUMN
+          flex_align_main: START
+          flex_align_cross: STRETCH
+          pad_row: 6
+        widgets: !include page_settings_tab_bijverwarmen_verwarmen_content.yaml
+
+    - obj:
+        id: panel_bijverwarmen_page_tapwater
+        hidden: true
+        width: 100%
+        height: SIZE_CONTENT
+        bg_opa: 0%
+        border_opa: 0%
+        pad_all: 0
+        scrollbar_mode: "OFF"
+        scrollable: false
+        layout:
+          type: FLEX
+          flex_flow: COLUMN
+          flex_align_main: START
+          flex_align_cross: STRETCH
+          pad_row: 6
+        widgets: !include page_settings_tab_bijverwarmen_tapwater_content.yaml
       
 # ------------------------------------------------------------
 

--- a/src/openamber/ui/settings/page_settings_tab_bijverwarmen.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_bijverwarmen.yaml
@@ -186,6 +186,52 @@ obj:
                         - number.increment: dhw_backup_min_avg_rate
                       widgets:
                         - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+
+      - obj:
+          width: 100%
+          height: SIZE_CONTENT
+          bg_opa: 0%
+          border_opa: 0%
+          pad_all: 6
+          widgets:
+            - label: { text: "Backupvertraging (Tapwater)", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+            - label: { text: "Tijd onder minimale verwarmsnelheid voordat backup inschakelt", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+            - obj:
+                width: SIZE_CONTENT
+                height: SIZE_CONTENT
+                align: TOP_RIGHT
+                bg_opa: 0%
+                border_opa: 0%
+                pad_all: 0
+                layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
+                widgets:
+                  - obj:
+                      width: 40
+                      height: 40
+                      bg_color: 0x1F3B68
+                      bg_opa: 100%
+                      radius: 10
+                      border_opa: 0%
+                      scrollbar_mode: "OFF"
+                      scrollable: false
+                      on_click:
+                        - number.decrement: dhw_backup_min_avg_rate_delay_minutes
+                      widgets:
+                        - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+                  - label: { id: set_dhw_rate_delay_val, text: "5 min", text_color: 0x1F2933, text_font: font_text_24 }
+                  - obj:
+                      width: 40
+                      height: 40
+                      bg_color: 0x1F3B68
+                      bg_opa: 100%
+                      radius: 10
+                      border_opa: 0%
+                      scrollbar_mode: "OFF"
+                      scrollable: false
+                      on_click:
+                        - number.increment: dhw_backup_min_avg_rate_delay_minutes
+                      widgets:
+                        - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
       
 # ------------------------------------------------------------
 

--- a/src/openamber/ui/settings/page_settings_tab_bijverwarmen_algemeen_content.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_bijverwarmen_algemeen_content.yaml
@@ -1,0 +1,73 @@
+- obj:
+    width: 100%
+    height: SIZE_CONTENT
+    bg_opa: 0%
+    border_opa: 0%
+    pad_all: 6
+    widgets:
+      - label: { text: "Backup element", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+      - label: { text: "Extern is voor Hybride opstellingen", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+      - dropdown:
+          id: set_backup_heating_mode_dd
+          symbol: "\U000F0140"
+          width: 320
+          align: TOP_RIGHT
+          y: 0
+          options:
+            - "Intern verwarmingselement"
+            - "Externe backup verwarming"
+          text_font: font_text_20
+          dropdown_list:
+            text_font: font_text_20
+          on_value:
+            then:
+              - lambda: |-
+                  auto val = lv_dropdown_get_selected(id(set_backup_heating_mode_dd)->obj);
+                  if (val == 0) id(backup_heating_mode).make_call().set_option("Intern verwarmingselement").perform();
+                  else id(backup_heating_mode).make_call().set_option("Externe backup verwarming").perform();
+
+- obj:
+    width: 100%
+    height: SIZE_CONTENT
+    bg_opa: 0%
+    border_opa: 0%
+    pad_all: 6
+    widgets:
+      - label: { text: "Boosttemperatuur bij ontdooien", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+      - label: { text: "Buitentemperatuur voor backup bij ontdooien", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+      - obj:
+          width: SIZE_CONTENT
+          height: SIZE_CONTENT
+          align: TOP_RIGHT
+          bg_opa: 0%
+          border_opa: 0%
+          pad_all: 0
+          layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
+          widgets:
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.decrement: defrost_backup_heater_boost_temperature_sensor
+                widgets:
+                  - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+            - label: { id: set_defrost_boost_val, text: "-3°C", text_color: 0x1F2933, text_font: font_text_24 }
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.increment: defrost_backup_heater_boost_temperature_sensor
+                widgets:
+                  - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }

--- a/src/openamber/ui/settings/page_settings_tab_bijverwarmen_tapwater_content.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_bijverwarmen_tapwater_content.yaml
@@ -1,0 +1,91 @@
+- obj:
+    width: 100%
+    height: SIZE_CONTENT
+    bg_opa: 0%
+    border_opa: 0%
+    pad_all: 6
+    widgets:
+      - label: { text: "Min. verwarmsnelheid", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+      - label: { text: "Minimale Tapwater-verwarmsnelheid; lager schakelt backup in", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+      - obj:
+          width: SIZE_CONTENT
+          height: SIZE_CONTENT
+          align: TOP_RIGHT
+          bg_opa: 0%
+          border_opa: 0%
+          pad_all: 0
+          layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
+          widgets:
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.decrement: dhw_backup_min_avg_rate
+                widgets:
+                  - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+            - label: { id: set_dhw_rate_val, text: "0.12 °C/min", text_color: 0x1F2933, text_font: font_text_24 }
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.increment: dhw_backup_min_avg_rate
+                widgets:
+                  - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+
+- obj:
+    width: 100%
+    height: SIZE_CONTENT
+    bg_opa: 0%
+    border_opa: 0%
+    pad_all: 6
+    widgets:
+      - label: { text: "Backupvertraging", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+      - label: { text: "Tijd onder minimale verwarmsnelheid voordat backup inschakelt", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+      - obj:
+          width: SIZE_CONTENT
+          height: SIZE_CONTENT
+          align: TOP_RIGHT
+          bg_opa: 0%
+          border_opa: 0%
+          pad_all: 0
+          layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
+          widgets:
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.decrement: dhw_backup_min_avg_rate_delay_minutes
+                widgets:
+                  - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+            - label: { id: set_dhw_rate_delay_val, text: "5 min", text_color: 0x1F2933, text_font: font_text_24 }
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.increment: dhw_backup_min_avg_rate_delay_minutes
+                widgets:
+                  - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }

--- a/src/openamber/ui/settings/page_settings_tab_bijverwarmen_verwarmen_content.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_bijverwarmen_verwarmen_content.yaml
@@ -1,0 +1,45 @@
+- obj:
+    width: 100%
+    height: SIZE_CONTENT
+    bg_opa: 0%
+    border_opa: 0%
+    pad_all: 6
+    widgets:
+      - label: { text: "Backup °min drempel", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+      - label: { text: "Graadminuten drempel voor backup element tijdens verwarmen", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+      - obj:
+          width: SIZE_CONTENT
+          height: SIZE_CONTENT
+          align: TOP_RIGHT
+          bg_opa: 0%
+          border_opa: 0%
+          pad_all: 0
+          layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
+          widgets:
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.decrement: backup_heater_degmin_threshold
+                widgets:
+                  - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+            - label: { id: set_degmin_val, text: "40 °C·min", text_color: 0x1F2933, text_font: font_text_24 }
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.increment: backup_heater_degmin_threshold
+                widgets:
+                  - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable domestic hot water backup delay (0–60 minutes) with live updates in the Tapwater settings UI.
  - Refreshed the “Bijverwarmen” settings page into a tabbed layout with smoother panel switching.

- **Bug Fixes**
  - Improved backup-heater activation so it only triggers after the heating rate stays below the configured minimum for the selected delay (including a short grace period).
  - Reset low-rate monitoring when the DHW pump stops and when backup-heater activation paths change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->