### PR TITLE
Add flow switch safety check delay

### DIFF
--- a/src/openamber/common/numbers.yaml
+++ b/src/openamber/common/numbers.yaml
@@ -872,6 +872,21 @@
     return x + 30;
 
 - platform: template
+  name: "Flow switch uitvalvertraging (minuten)"
+  id: flow_switch_safety_delay_minutes
+  optimistic: True
+  restore_value: True
+  min_value: 0
+  max_value: 10
+  step: 1
+  unit_of_measurement: "min"
+  icon: "mdi:timer-alert-outline"
+  initial_value: 0
+  entity_category: config
+  web_server:
+      sorting_group_id: general_settings
+
+- platform: template
   name: "Pomp interval (minuten)"
   id: pump_interval
   optimistic: True

--- a/src/openamber/controllers/dhw_controller.h
+++ b/src/openamber/controllers/dhw_controller.h
@@ -255,7 +255,7 @@ private:
     }
 
     // Stop compressor only if pump flow stays missing for the configured delay while compressor runs.
-    if (compressor_controller_->IsRunning() && !pump_controller_->IsRunning())
+    if (state_ != DHWState::IDLE && compressor_controller_->IsRunning() && !pump_controller_->IsRunning())
     {
       const uint32_t now = App.get_loop_component_start_time();
       const uint32_t flow_switch_delay_ms = static_cast<uint32_t>(id(flow_switch_safety_delay_minutes).state * 60000.0f);
@@ -270,6 +270,7 @@ private:
       {
         ESP_LOGW("amber", "Safety check: Pump flow missing for %.0f min while compressor is running, stopping compressor to avoid damage.", id(flow_switch_safety_delay_minutes).state);
         compressor_controller_->Stop();
+        pump_controller_->Stop();
         StopDhwPump();
         TurnOffBackupHeater();
         id(dhw_active).publish_state(false);

--- a/src/openamber/controllers/dhw_controller.h
+++ b/src/openamber/controllers/dhw_controller.h
@@ -47,6 +47,7 @@ private:
   float last_temperature_rate_ = 0.0f;
   float last_measured_temperature_ = 0.0f;
   float dhw_pump_settled_time_ = 0.0f;
+  uint32_t pump_flow_missing_since_ms_ = 0;
 
   const char* StateToString(DHWState state) const override
   {
@@ -253,16 +254,32 @@ private:
       return;
     }
 
-    // If pump is not active while compressor is running, stop compressor to avoid damage
+    // Stop compressor only if pump flow stays missing for the configured delay while compressor runs.
     if (compressor_controller_->IsRunning() && !pump_controller_->IsRunning())
     {
-      ESP_LOGW("amber", "Safety check: Pump is not active while compressor is running, stopping compressor to avoid damage.");
-      compressor_controller_->Stop();
-      StopDhwPump();
-      TurnOffBackupHeater();
-      id(dhw_active).publish_state(false);
-      SetNextState(DHWState::IDLE);
-      return;
+      const uint32_t now = App.get_loop_component_start_time();
+      const uint32_t flow_switch_delay_ms = static_cast<uint32_t>(id(flow_switch_safety_delay_minutes).state * 60000.0f);
+
+      if (pump_flow_missing_since_ms_ == 0)
+      {
+        pump_flow_missing_since_ms_ = now;
+        ESP_LOGW("amber", "Safety check: Pump flow missing while compressor is running, waiting %.0f min before shutdown.", id(flow_switch_safety_delay_minutes).state);
+      }
+
+      if ((now - pump_flow_missing_since_ms_) >= flow_switch_delay_ms)
+      {
+        ESP_LOGW("amber", "Safety check: Pump flow missing for %.0f min while compressor is running, stopping compressor to avoid damage.", id(flow_switch_safety_delay_minutes).state);
+        compressor_controller_->Stop();
+        StopDhwPump();
+        TurnOffBackupHeater();
+        id(dhw_active).publish_state(false);
+        SetNextState(DHWState::IDLE);
+        return;
+      }
+    }
+    else
+    {
+      pump_flow_missing_since_ms_ = 0;
     }
 
     // If Tuo - Tui is above 15 degrees while compressor is running, stop compressor to avoid damage

--- a/src/openamber/controllers/heat_cool_controller.h
+++ b/src/openamber/controllers/heat_cool_controller.h
@@ -48,6 +48,7 @@ private:
   float compressor_heat_pid_ = 0.0f;
   float compressor_cool_pid_ = 0.0f;
   float start_current_temperature_ = 0.0f;
+  uint32_t pump_flow_missing_since_ms_ = 0;
 
   const char* StateToString(HeatCoolState state) const override
   {
@@ -282,15 +283,31 @@ private:
       return;
     }
 
-    // If pump is not active while compressor is running, stop compressor to avoid damage
+    // Stop compressor only if pump flow stays missing for the configured delay while compressor runs.
     if (compressor_controller_->IsRunning() && !pump_controller_->IsRunning())
     {
-      ESP_LOGW("amber", "Safety check: Pump is not active while compressor is running, stopping compressor to avoid damage.");
-      compressor_controller_->Stop();
-      TurnOffBackupHeater();
-      StopPumps();
-      SetNextState(HeatCoolState::IDLE);
-      return;
+      const uint32_t now = App.get_loop_component_start_time();
+      const uint32_t flow_switch_delay_ms = static_cast<uint32_t>(id(flow_switch_safety_delay_minutes).state * 60000.0f);
+
+      if (pump_flow_missing_since_ms_ == 0)
+      {
+        pump_flow_missing_since_ms_ = now;
+        ESP_LOGW("amber", "Safety check: Pump flow missing while compressor is running, waiting %.0f min before shutdown.", id(flow_switch_safety_delay_minutes).state);
+      }
+
+      if ((now - pump_flow_missing_since_ms_) >= flow_switch_delay_ms)
+      {
+        ESP_LOGW("amber", "Safety check: Pump flow missing for %.0f min while compressor is running, stopping compressor to avoid damage.", id(flow_switch_safety_delay_minutes).state);
+        compressor_controller_->Stop();
+        TurnOffBackupHeater();
+        StopPumps();
+        SetNextState(HeatCoolState::IDLE);
+        return;
+      }
+    }
+    else
+    {
+      pump_flow_missing_since_ms_ = 0;
     }
 
     // If temperature difference between Tuo and Tui is above 8 degrees while compressor is running, stop compressor to avoid damage

--- a/src/openamber/controllers/heat_cool_controller.h
+++ b/src/openamber/controllers/heat_cool_controller.h
@@ -284,7 +284,7 @@ private:
     }
 
     // Stop compressor only if pump flow stays missing for the configured delay while compressor runs.
-    if (compressor_controller_->IsRunning() && !pump_controller_->IsRunning())
+    if (state_ != HeatCoolState::IDLE && compressor_controller_->IsRunning() && !pump_controller_->IsRunning())
     {
       const uint32_t now = App.get_loop_component_start_time();
       const uint32_t flow_switch_delay_ms = static_cast<uint32_t>(id(flow_switch_safety_delay_minutes).state * 60000.0f);

--- a/src/openamber/ui/bindings/number_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/number_ui_bindings.yaml
@@ -197,6 +197,15 @@
             format: "%.0f min"
             args: ['x']
 
+- id: !extend flow_switch_safety_delay_minutes
+  on_value:
+    then:
+      - lvgl.label.update:
+          id: set_pump_flow_switch_safety_delay_val
+          text:
+            format: "%.0f min"
+            args: ['x']
+
 # ── Compressor ──
 - id: !extend compressor_start_delta_heating
   on_value:

--- a/src/openamber/ui/bindings/script_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/script_ui_bindings.yaml
@@ -909,6 +909,13 @@
           - lvgl.widget.update:
               id: set_defrost_advanced_section
               opa: 100%
+          - lvgl.widget.update:
+              id: set_pump_flow_switch_safety_row
+              state:
+                disabled: false
+          - lvgl.widget.update:
+              id: set_pump_flow_switch_safety_row
+              opa: 100%
           - script.execute: update_bottomplate_mode_ui
         else:
           - lvgl.widget.hide: { id: panel_advanced }
@@ -975,6 +982,13 @@
                 disabled: true
           - lvgl.widget.update:
               id: set_defrost_advanced_section
+              opa: 40%
+          - lvgl.widget.update:
+              id: set_pump_flow_switch_safety_row
+              state:
+                disabled: true
+          - lvgl.widget.update:
+              id: set_pump_flow_switch_safety_row
               opa: 40%
 
 - id: update_service_valve_ui

--- a/src/openamber/ui/settings/page_settings_sidebar.yaml
+++ b/src/openamber/ui/settings/page_settings_sidebar.yaml
@@ -171,6 +171,7 @@
             - lvgl.widget.update: { id: stab_wifi_lbl, text_color: 0x4B5563 }
             - lvgl.widget.update: { id: stab_thermostat, bg_color: 0xE8ECF1 }
             - lvgl.widget.update: { id: stab_thermostat_lbl, text_color: 0x4B5563 }
+            - script.execute: update_advanced_settings_ui
           widgets:
             - label: { id: stab_pump_lbl, text: "Pomp", text_color: 0x4B5563, text_font: font_text_20, align: LEFT_MID }
       - obj:

--- a/src/openamber/ui/settings/page_settings_tab_general.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_general.yaml
@@ -11,7 +11,7 @@ obj:
   pad_top: 4
   pad_bottom: 4
   scrollbar_mode: "OFF"
-  scrollable: true
+  scrollable: false
   layout:
     type: FLEX
     flex_flow: COLUMN

--- a/src/openamber/ui/settings/page_settings_tab_pump_algemeen_content.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_pump_algemeen_content.yaml
@@ -117,6 +117,53 @@
                   - number.increment: pump_duration
                 widgets:
                   - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+
+- obj:
+    id: set_pump_flow_switch_safety_row
+    width: 100%
+    height: SIZE_CONTENT
+    bg_opa: 0%
+    border_opa: 0%
+    pad_all: 6
+    widgets:
+      - label: { text: "Flow switch uitvalvertraging (min)", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+      - label: { text: "Stop bij geen flow na ingesteld aantal minuten", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+      - obj:
+          width: SIZE_CONTENT
+          height: SIZE_CONTENT
+          align: TOP_RIGHT
+          bg_opa: 0%
+          border_opa: 0%
+          pad_all: 0
+          layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
+          widgets:
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.decrement: flow_switch_safety_delay_minutes
+                widgets:
+                  - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+            - label: { id: set_pump_flow_switch_safety_delay_val, text: "0 min", text_color: 0x1F2933, text_font: font_text_24 }
+            - obj:
+                width: 40
+                height: 40
+                bg_color: 0x1F3B68
+                bg_opa: 100%
+                radius: 10
+                border_opa: 0%
+                scrollbar_mode: "OFF"
+                scrollable: false
+                on_click:
+                  - number.increment: flow_switch_safety_delay_minutes
+                widgets:
+                  - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
       
                 # ------------------------------------------------------------
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable **Flow switch uitvalvertraging (minuten)** safety delay (0–10 minutes) to pump settings.
* **Improvements**
  * Heating and domestic hot water safety shutdowns are now **delay-based** when compressor runs but pump flow is missing.
  * If flow returns before the delay elapses, shutdown is **avoided**.
* **UI**
  * Added the delay value row with step controls and live minutes display.
  * Refreshed advanced-settings UI visibility when relevant options change.
  * Updated general settings panel scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->