### PR TITLE
Fixed to check if schedule is active before starting legionella run

### DIFF
--- a/src/openamber/controllers/dhw_controller.h
+++ b/src/openamber/controllers/dhw_controller.h
@@ -585,7 +585,8 @@ public:
       ESP_LOGW("amber", "WARNING: Time is not synchronized, skipping legionella cycle check.");
       return;
     }
-    if(!id(dhw_legionella_run_active_sensor).state && now >= legionella_time)
+  
+    if(!id(dhw_legionella_run_active_sensor).state && now >= legionella_time && id(dhw_schedule_active_sensor).state)
     {
       ESP_LOGI("amber", "Starting legionella cycle.");
       id(dhw_legionella_run_active_sensor).publish_state(true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legionella cycles now start only when the domestic hot water schedule is active, preventing unscheduled cycle runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->