### PR TITLE
Add button to dump EEPROM and send it to analytics platform

### DIFF
--- a/src/openamber/common/openamber.yaml
+++ b/src/openamber/common/openamber.yaml
@@ -304,6 +304,15 @@ button:
   - platform: restart
     id: restart_openamber
     name: Restart OpenAmber
+  - platform: template
+    id: dump_eeprom_parameters_button
+    name: "Dump EEPROM parameters"
+    disabled_by_default: true
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: diagnostic
+    on_press:
+      - script.execute: dump_eeprom_parameters
 
 preferences:
  flash_write_interval: 5min

--- a/src/openamber/common/scripts.yaml
+++ b/src/openamber/common/scripts.yaml
@@ -412,7 +412,7 @@
     - script.execute: fetch_analytics_device_id
 
 - id: dump_eeprom_parameters
-  mode: restart
+  mode: single
   then:
     - lvgl.widget.disable: { id: service_eeprom_dump_button }
     - if:
@@ -424,40 +424,51 @@
                 lambda: 'return id(mqtt_client).is_connected();'
               then:
                 - lambda: |-
-                    static int dump_request_sequence = 0;
+                    static bool in_progress = false;
+                    static int request_sequence = 0;
                     static int pending_chunks = 0;
-                    const int request_seq = ++dump_request_sequence;
+                    if (in_progress) {
+                      ESP_LOGW("amber", "EEPROM dump overgeslagen: er loopt al een dump");
+                      lv_obj_clear_state(id(service_eeprom_dump_button), LV_STATE_DISABLED);
+                      return;
+                    }
+                    in_progress = true;
+                    const int request_seq = ++request_sequence;
                     pending_chunks = 5;
                     const int64_t request_ts = id(my_time).timestamp_now();
-                    auto queue_chunk = [request_seq, request_ts](uint16_t start_address, uint16_t register_count, uint8_t chunk_index) {
+                    auto complete_chunk = [request_seq](bool failed) {
+                      if (request_seq != request_sequence) {
+                        return;
+                      }
+                      if (failed) {
+                        ESP_LOGE("amber", "EEPROM dump chunk mislukt");
+                      }
+                      if (--pending_chunks <= 0) {
+                        pending_chunks = 0;
+                        in_progress = false;
+                        lv_obj_clear_state(id(service_eeprom_dump_button), LV_STATE_DISABLED);
+                      }
+                    };
+                    auto queue_chunk = [request_seq, request_ts, complete_chunk](uint16_t start_address, uint16_t register_count, uint8_t chunk_index) {
                       auto command = esphome::modbus_controller::ModbusCommandItem::create_read_command(
                         id(modbus_outside_unit),
                         esphome::modbus_controller::ModbusRegisterType::HOLDING,
                         start_address,
                         register_count,
-                        [request_seq, request_ts, start_address, register_count, chunk_index](
+                            [request_seq, request_ts, start_address, register_count, chunk_index, complete_chunk](
                             esphome::modbus_controller::ModbusRegisterType register_type,
                             uint16_t response_start_address,
                             const std::vector<uint8_t> &data) {
                           (void) register_type;
                           (void) response_start_address;
-                            auto complete_chunk = [request_seq]() {
-                              if (request_seq != dump_request_sequence) {
-                                return;
-                              }
-                              if (--pending_chunks <= 0) {
-                                pending_chunks = 0;
-                                lv_obj_clear_state(id(service_eeprom_dump_button), LV_STATE_DISABLED);
-                              }
-                            };
-                          if (request_seq != dump_request_sequence) {
+                          if (request_seq != request_sequence) {
                             return;
                           }
                           const size_t expected_bytes = register_count * 2;
                           if (data.size() < expected_bytes) {
                             ESP_LOGE("amber", "EEPROM dump chunk %u mislukt: verwachtte %u bytes, kreeg %u",
                                      chunk_index, expected_bytes, data.size());
-                            complete_chunk();
+                            complete_chunk(true);
                             return;
                           }
 
@@ -480,13 +491,13 @@
                           const std::string topic = id(analytics_topic) + "/eeprom_dump/chunk/" + std::to_string(chunk_index);
                           if (!id(mqtt_client).publish(topic, payload, 0, false)) {
                             ESP_LOGE("amber", "EEPROM dump chunk %u kon niet naar MQTT worden gepubliceerd", chunk_index);
-                            complete_chunk();
+                            complete_chunk(true);
                             return;
                           }
 
                           ESP_LOGI("amber", "EEPROM dump chunk %u gepubliceerd (%u-%u)", chunk_index, start_address + 1,
                                    start_address + register_count);
-                          complete_chunk();
+                          complete_chunk(false);
                         });
                       id(modbus_outside_unit)->queue_command(command);
                     };

--- a/src/openamber/common/scripts.yaml
+++ b/src/openamber/common/scripts.yaml
@@ -410,3 +410,96 @@
     - script.execute: send_telemetry_4
     - delay: 150ms
     - script.execute: fetch_analytics_device_id
+
+- id: dump_eeprom_parameters
+  mode: restart
+  then:
+    - lvgl.widget.disable: { id: service_eeprom_dump_button }
+    - if:
+        condition:
+          lambda: 'return id(modbus_outside_is_online);'
+        then:
+          - if:
+              condition:
+                lambda: 'return id(mqtt_client).is_connected();'
+              then:
+                - lambda: |-
+                    static int dump_request_sequence = 0;
+                    static int pending_chunks = 0;
+                    const int request_seq = ++dump_request_sequence;
+                    pending_chunks = 5;
+                    const int64_t request_ts = id(my_time).timestamp_now();
+                    auto queue_chunk = [request_seq, request_ts](uint16_t start_address, uint16_t register_count, uint8_t chunk_index) {
+                      auto command = esphome::modbus_controller::ModbusCommandItem::create_read_command(
+                        id(modbus_outside_unit),
+                        esphome::modbus_controller::ModbusRegisterType::HOLDING,
+                        start_address,
+                        register_count,
+                        [request_seq, request_ts, start_address, register_count, chunk_index](
+                            esphome::modbus_controller::ModbusRegisterType register_type,
+                            uint16_t response_start_address,
+                            const std::vector<uint8_t> &data) {
+                          (void) register_type;
+                          (void) response_start_address;
+                            auto complete_chunk = [request_seq]() {
+                              if (request_seq != dump_request_sequence) {
+                                return;
+                              }
+                              if (--pending_chunks <= 0) {
+                                pending_chunks = 0;
+                                lv_obj_clear_state(id(service_eeprom_dump_button), LV_STATE_DISABLED);
+                              }
+                            };
+                          if (request_seq != dump_request_sequence) {
+                            return;
+                          }
+                          const size_t expected_bytes = register_count * 2;
+                          if (data.size() < expected_bytes) {
+                            ESP_LOGE("amber", "EEPROM dump chunk %u mislukt: verwachtte %u bytes, kreeg %u",
+                                     chunk_index, expected_bytes, data.size());
+                            complete_chunk();
+                            return;
+                          }
+
+                          std::string payload = "{\"ts\":";
+                          payload += std::to_string(request_ts);
+                          payload += ",\"start\":";
+                          payload += std::to_string(start_address + 1);
+                          payload += ",\"count\":";
+                          payload += std::to_string(register_count);
+                          payload += ",\"values\":[";
+                          for (size_t i = 0; i < register_count; i++) {
+                            const size_t offset = i * 2;
+                            const uint16_t value = (static_cast<uint16_t>(data[offset]) << 8) |
+                                                   static_cast<uint16_t>(data[offset + 1]);
+                            if (i > 0) payload += ",";
+                            payload += std::to_string(value);
+                          }
+                          payload += "]}";
+
+                          const std::string topic = id(analytics_topic) + "/eeprom_dump/chunk/" + std::to_string(chunk_index);
+                          if (!id(mqtt_client).publish(topic, payload, 0, false)) {
+                            ESP_LOGE("amber", "EEPROM dump chunk %u kon niet naar MQTT worden gepubliceerd", chunk_index);
+                            complete_chunk();
+                            return;
+                          }
+
+                          ESP_LOGI("amber", "EEPROM dump chunk %u gepubliceerd (%u-%u)", chunk_index, start_address + 1,
+                                   start_address + register_count);
+                          complete_chunk();
+                        });
+                      id(modbus_outside_unit)->queue_command(command);
+                    };
+
+                    queue_chunk(2999, 125, 0);
+                    queue_chunk(3124, 125, 1);
+                    queue_chunk(3249, 125, 2);
+                    queue_chunk(3374, 125, 3);
+                    queue_chunk(3499, 12, 4);
+                - logger.log: "EEPROM dump gestart (3000 t/m 3511)"
+              else:
+                - logger.log: "EEPROM dump geannuleerd: MQTT niet verbonden"
+                - lvgl.widget.enable: { id: service_eeprom_dump_button }
+        else:
+          - logger.log: "EEPROM dump geannuleerd: buitenunit Modbus offline"
+          - lvgl.widget.enable: { id: service_eeprom_dump_button }

--- a/src/openamber/ui/bindings/script_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/script_ui_bindings.yaml
@@ -1205,6 +1205,7 @@
     - lvgl.widget.show: { id: service_tabs_bar }
     - lvgl.widget.hide: { id: service_maintenance_panel }
     - lvgl.widget.hide: { id: service_sensors_panel }
+    - lvgl.widget.hide: { id: service_eeprom_panel }
     - lvgl.widget.show: { id: service_errors_panel }
     - lvgl.widget.hide: { id: service_warnings_panel }
     - lvgl.widget.hide: { id: service_mpanel_compressor }
@@ -1245,6 +1246,7 @@
     - lvgl.widget.show: { id: service_tabs_bar }
     - lvgl.widget.hide: { id: service_maintenance_panel }
     - lvgl.widget.hide: { id: service_sensors_panel }
+    - lvgl.widget.hide: { id: service_eeprom_panel }
     - lvgl.widget.hide: { id: service_errors_panel }
     - lvgl.widget.show: { id: service_warnings_panel }
     - lvgl.widget.hide: { id: service_mpanel_compressor }
@@ -1798,6 +1800,11 @@
                 - lvgl.widget.update:
                     id: service_maintenance_state
                     text_color: 0x6B7280
+                - if:
+                    condition:
+                      lambda: 'return !id(service_mode_enabled).state && !lv_obj_has_flag(id(service_maintenance_panel), LV_OBJ_FLAG_HIDDEN);'
+                    then:
+                      - lvgl.widget.show: { id: service_maintenance_lock_hint }
           - lvgl.widget.hide: { id: service_mpanel_compressor }
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }

--- a/src/openamber/ui/bindings/script_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/script_ui_bindings.yaml
@@ -194,6 +194,7 @@
                             - lvgl.widget.hide: { id: service_mpanel_pumps }
                             - lvgl.widget.hide: { id: service_mpanel_valve }
                             - lvgl.widget.hide: { id: service_mpanel_backup }
+                            - lvgl.widget.hide: { id: service_eeprom_panel }
                             - script.execute: update_service_mode_ui
                             - script.execute: update_service_top_tabs_ui
                           else:
@@ -1049,6 +1050,7 @@
 - id: update_service_section_options_ui
   mode: restart
   then:
+    - lvgl.widget.enable: { id: service_tab_eeprom }
     - if:
         condition:
           lambda: 'return id(service_mode_enabled).state && id(state_machine_state_main).state == "Maintenance";'
@@ -1064,7 +1066,7 @@
           - lvgl.widget.disable: { id: service_tab_backup }
           - if:
               condition:
-                lambda: 'return lv_obj_has_flag(id(service_sensors_panel), LV_OBJ_FLAG_HIDDEN) && lv_obj_has_flag(id(service_errors_panel), LV_OBJ_FLAG_HIDDEN) && lv_obj_has_flag(id(service_warnings_panel), LV_OBJ_FLAG_HIDDEN);'
+                lambda: 'return lv_obj_has_flag(id(service_sensors_panel), LV_OBJ_FLAG_HIDDEN) && lv_obj_has_flag(id(service_errors_panel), LV_OBJ_FLAG_HIDDEN) && lv_obj_has_flag(id(service_warnings_panel), LV_OBJ_FLAG_HIDDEN) && lv_obj_has_flag(id(service_eeprom_panel), LV_OBJ_FLAG_HIDDEN);'
               then:
                 - lvgl.widget.show: { id: service_maintenance_panel }
                 - lvgl.widget.show: { id: service_maintenance_header }
@@ -1118,6 +1120,15 @@
         else:
           - lvgl.widget.update: { id: service_tab_backup, bg_color: 0xE8ECF1 }
           - lvgl.widget.update: { id: service_tab_backup_lbl, text_color: 0x4B5563 }
+    - if:
+        condition:
+          lambda: 'return lv_obj_has_state(id(service_tab_eeprom), LV_STATE_DISABLED);'
+        then:
+          - lvgl.widget.update: { id: service_tab_eeprom, bg_color: 0xEDF1F6 }
+          - lvgl.widget.update: { id: service_tab_eeprom_lbl, text_color: 0x9CA3AF }
+        else:
+          - lvgl.widget.update: { id: service_tab_eeprom, bg_color: 0xE8ECF1 }
+          - lvgl.widget.update: { id: service_tab_eeprom_lbl, text_color: 0x4B5563 }
     - lvgl.widget.update: { id: service_tab_sensors, bg_color: 0xE8ECF1 }
     - lvgl.widget.update: { id: service_tab_sensors_lbl, text_color: 0x4B5563 }
     - lvgl.widget.update: { id: service_tab_errors, bg_color: 0xE8ECF1 }
@@ -1161,20 +1172,27 @@
                                 else:
                                   - if:
                                       condition:
-                                        lambda: 'return !lv_obj_has_flag(id(service_mpanel_valve), LV_OBJ_FLAG_HIDDEN);'
+                                        lambda: 'return !lv_obj_has_flag(id(service_eeprom_panel), LV_OBJ_FLAG_HIDDEN);'
                                       then:
-                                        - lvgl.widget.update: { id: service_tab_valve, bg_color: 0x1F3B68 }
-                                        - lvgl.widget.update: { id: service_tab_valve_lbl, text_color: 0xFFFFFF }
+                                        - lvgl.widget.update: { id: service_tab_eeprom, bg_color: 0x1F3B68 }
+                                        - lvgl.widget.update: { id: service_tab_eeprom_lbl, text_color: 0xFFFFFF }
                                       else:
                                         - if:
                                             condition:
-                                              lambda: 'return !lv_obj_has_flag(id(service_mpanel_backup), LV_OBJ_FLAG_HIDDEN);'
+                                              lambda: 'return !lv_obj_has_flag(id(service_mpanel_valve), LV_OBJ_FLAG_HIDDEN);'
                                             then:
-                                              - lvgl.widget.update: { id: service_tab_backup, bg_color: 0x1F3B68 }
-                                              - lvgl.widget.update: { id: service_tab_backup_lbl, text_color: 0xFFFFFF }
+                                              - lvgl.widget.update: { id: service_tab_valve, bg_color: 0x1F3B68 }
+                                              - lvgl.widget.update: { id: service_tab_valve_lbl, text_color: 0xFFFFFF }
                                             else:
-                                              - lvgl.widget.update: { id: service_tab_maintenance, bg_color: 0x1F3B68 }
-                                              - lvgl.widget.update: { id: service_tab_maintenance_lbl, text_color: 0xFFFFFF }
+                                              - if:
+                                                  condition:
+                                                    lambda: 'return !lv_obj_has_flag(id(service_mpanel_backup), LV_OBJ_FLAG_HIDDEN);'
+                                                  then:
+                                                    - lvgl.widget.update: { id: service_tab_backup, bg_color: 0x1F3B68 }
+                                                    - lvgl.widget.update: { id: service_tab_backup_lbl, text_color: 0xFFFFFF }
+                                                  else:
+                                                    - lvgl.widget.update: { id: service_tab_maintenance, bg_color: 0x1F3B68 }
+                                                    - lvgl.widget.update: { id: service_tab_maintenance_lbl, text_color: 0xFFFFFF }
 
 - id: open_service_errors_tab
   mode: restart
@@ -1780,7 +1798,6 @@
                 - lvgl.widget.update:
                     id: service_maintenance_state
                     text_color: 0x6B7280
-          - lvgl.widget.show: { id: service_maintenance_lock_hint }
           - lvgl.widget.hide: { id: service_mpanel_compressor }
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }

--- a/src/openamber/ui/page_service.yaml
+++ b/src/openamber/ui/page_service.yaml
@@ -57,3 +57,4 @@ obj:
                 - !include service/page_service_tab_sensors.yaml
                 - !include service/page_service_tab_errors.yaml
                 - !include service/page_service_tab_warnings.yaml
+                - !include service/page_service_tab_eeprom.yaml

--- a/src/openamber/ui/service/page_service_sidebar.yaml
+++ b/src/openamber/ui/service/page_service_sidebar.yaml
@@ -45,11 +45,13 @@
           - lvgl.widget.show: { id: service_maintenance_title }
           - lvgl.widget.show: { id: service_maintenance_state }
           - lvgl.widget.show: { id: set_service_mode_switch_ui }
+          - lvgl.widget.show: { id: service_maintenance_lock_hint }
           - lvgl.widget.update: { id: service_maintenance_layout, y: 112, height: 72% }
           - lvgl.widget.hide: { id: service_mpanel_compressor }
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }
           - lvgl.widget.hide: { id: service_mpanel_backup }
+          - lvgl.widget.hide: { id: service_eeprom_panel }
           - script.execute: update_service_mode_ui
         widgets:
           - label:
@@ -80,11 +82,13 @@
           - lvgl.widget.hide: { id: service_maintenance_title }
           - lvgl.widget.hide: { id: service_maintenance_state }
           - lvgl.widget.hide: { id: set_service_mode_switch_ui }
+          - lvgl.widget.hide: { id: service_maintenance_lock_hint }
           - lvgl.widget.update: { id: service_maintenance_layout, y: 0, height: 100% }
           - lvgl.widget.show: { id: service_mpanel_compressor }
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }
           - lvgl.widget.hide: { id: service_mpanel_backup }
+          - lvgl.widget.hide: { id: service_eeprom_panel }
           - script.execute: update_service_mode_ui
         widgets:
           - label:
@@ -120,6 +124,7 @@
           - lvgl.widget.show: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }
           - lvgl.widget.hide: { id: service_mpanel_backup }
+          - lvgl.widget.hide: { id: service_eeprom_panel }
           - script.execute: update_service_mode_ui
         widgets:
           - label:
@@ -155,6 +160,7 @@
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.show: { id: service_mpanel_valve }
           - lvgl.widget.hide: { id: service_mpanel_backup }
+          - lvgl.widget.hide: { id: service_eeprom_panel }
           - script.execute: update_service_mode_ui
         widgets:
           - label:
@@ -190,11 +196,48 @@
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }
           - lvgl.widget.show: { id: service_mpanel_backup }
+          - lvgl.widget.hide: { id: service_eeprom_panel }
           - script.execute: update_service_mode_ui
         widgets:
           - label:
               id: service_tab_backup_lbl
               text: "Back-up"
+              text_color: 0x4B5563
+              text_font: font_text_20
+              align: LEFT_MID
+
+    - obj:
+        id: service_tab_eeprom
+        width: 100%
+        height: 40
+        bg_color: 0xE8ECF1
+        bg_opa: 100%
+        radius: 10
+        border_width: 0
+        border_opa: 0%
+        pad_left: 12
+        pad_top: 2
+        pad_bottom: 2
+        on_click:
+          - lvgl.widget.hide: { id: service_maintenance_panel }
+          - lvgl.widget.hide: { id: service_sensors_panel }
+          - lvgl.widget.hide: { id: service_errors_panel }
+          - lvgl.widget.hide: { id: service_warnings_panel }
+          - lvgl.widget.hide: { id: service_maintenance_header }
+          - lvgl.widget.hide: { id: service_maintenance_title }
+          - lvgl.widget.hide: { id: service_maintenance_state }
+          - lvgl.widget.hide: { id: set_service_mode_switch_ui }
+          - lvgl.widget.update: { id: service_maintenance_layout, y: 0, height: 100% }
+          - lvgl.widget.show: { id: service_eeprom_panel }
+          - lvgl.widget.hide: { id: service_mpanel_compressor }
+          - lvgl.widget.hide: { id: service_mpanel_pumps }
+          - lvgl.widget.hide: { id: service_mpanel_valve }
+          - lvgl.widget.hide: { id: service_mpanel_backup }
+          - script.execute: update_service_mode_ui
+        widgets:
+          - label:
+              id: service_tab_eeprom_lbl
+              text: "EEPROM"
               text_color: 0x4B5563
               text_font: font_text_20
               align: LEFT_MID
@@ -220,6 +263,7 @@
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }
           - lvgl.widget.hide: { id: service_mpanel_backup }
+          - lvgl.widget.hide: { id: service_eeprom_panel }
           - script.execute: update_service_mode_ui
         widgets:
           - label:
@@ -250,6 +294,7 @@
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }
           - lvgl.widget.hide: { id: service_mpanel_backup }
+          - lvgl.widget.hide: { id: service_eeprom_panel }
           - script.execute: update_service_mode_ui
           - script.execute: update_service_errors_ui
         widgets:
@@ -281,6 +326,7 @@
           - lvgl.widget.hide: { id: service_mpanel_pumps }
           - lvgl.widget.hide: { id: service_mpanel_valve }
           - lvgl.widget.hide: { id: service_mpanel_backup }
+          - lvgl.widget.hide: { id: service_eeprom_panel }
           - script.execute: update_service_mode_ui
           - script.execute: update_service_warnings_ui
         widgets:

--- a/src/openamber/ui/service/page_service_tab_eeprom.yaml
+++ b/src/openamber/ui/service/page_service_tab_eeprom.yaml
@@ -1,0 +1,37 @@
+obj:
+  id: service_eeprom_panel
+  width: 100%
+  height: 100%
+  hidden: true
+  bg_opa: 0%
+  border_opa: 0%
+  pad_all: 0
+  widgets:
+    - label:
+        text: "EEPROM Dump (Alleen lezen)"
+        text_color: 0x1F2933
+        text_font: font_text_24
+        align: TOP_LEFT
+    - label:
+        text: "Verzend EEPROM parameters naar OpenAmber Analytics."
+        width: 72%
+        text_color: 0x6B7280
+        text_font: font_text_20
+        align: TOP_LEFT
+        y: 34
+    - button:
+        id: service_eeprom_dump_button
+        width: 200
+        height: 56
+        align: TOP_RIGHT
+        bg_color: 0x1F3B68
+        radius: 10
+        on_click:
+          - lvgl.widget.disable: { id: service_eeprom_dump_button }
+          - script.execute: dump_eeprom_parameters
+        widgets:
+          - label:
+              text: "Dump EEPROM"
+              text_color: 0xFFFFFF
+              text_font: font_text_20
+              align: CENTER


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an EEPROM diagnostic panel to the service page.
  * Added a “Dump EEPROM” button to retrieve and publish EEPROM parameters.
  * Added navigation and visibility handling for the new EEPROM service tab.
  * The diagnostic control is disabled by default and during active data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->