### PR TITLE
Add room temperature to thermostat screen

### DIFF
--- a/src/openamber/ui/bindings/script_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/script_ui_bindings.yaml
@@ -165,7 +165,7 @@
                 - lvgl.widget.update: { id: page_service, hidden: true }
                 - lvgl.widget.update: { id: page_system, hidden: true }
                 - lvgl.widget.update: { id: page_settings, hidden: true }
-                - script.execute: update_home_thermostat_mode_ui
+                - script.execute: update_thermostat_settings_ui
               else:
                 - if:
                     condition:

--- a/src/openamber/ui/nav_bar.yaml
+++ b/src/openamber/ui/nav_bar.yaml
@@ -84,7 +84,6 @@ obj:
           - script.execute:
               id: nav_select_tab
               tab_index: 1
-          - script.execute: update_thermostat_settings_ui
         widgets:
           - label:
               id: nav_thermostat_icon

--- a/src/openamber/ui/nav_bar.yaml
+++ b/src/openamber/ui/nav_bar.yaml
@@ -84,7 +84,7 @@ obj:
           - script.execute:
               id: nav_select_tab
               tab_index: 1
-          - script.execute: update_home_thermostat_mode_ui
+          - script.execute: update_thermostat_settings_ui
         widgets:
           - label:
               id: nav_thermostat_icon

--- a/src/openamber/ui/page_thermostat.yaml
+++ b/src/openamber/ui/page_thermostat.yaml
@@ -312,6 +312,60 @@ obj:
                                                         text_font: font_text_20
 
                             - obj:
+                                id: home_therm_current_temp_column
+                                width: SIZE_CONTENT
+                                height: SIZE_CONTENT
+                                bg_opa: 0%
+                                border_width: 0
+                                border_opa: 0%
+                                pad_all: 0
+                                layout:
+                                  type: FLEX
+                                  flex_flow: COLUMN
+                                  flex_align_main: START
+                                  flex_align_cross: CENTER
+                                  pad_row: 6
+                                widgets:
+                                  - label:
+                                      id: home_therm_current_temp_title
+                                      text: "Kamertemperatuur"
+                                      text_color: 0x0F172A
+                                      text_font: font_text_20
+                                  - obj:
+                                      id: home_therm_current_temp_card
+                                      width: SIZE_CONTENT
+                                      height: 58
+                                      bg_color: 0xFFFFFF
+                                      bg_opa: 100%
+                                      radius: 12
+                                      border_width: 1
+                                      border_color: 0xCBD5E1
+                                      border_opa: 100%
+                                      pad_left: 14
+                                      pad_right: 14
+                                      pad_top: 0
+                                      pad_bottom: 0
+                                      scrollbar_mode: "OFF"
+                                      scrollable: false
+                                      layout:
+                                        type: FLEX
+                                        flex_flow: ROW
+                                        flex_align_cross: CENTER
+                                        flex_align_main: CENTER
+                                        pad_column: 8
+                                      widgets:
+                                        - label:
+                                            id: home_therm_current_temp_icon
+                                            text: "\U000F050F"
+                                            text_color: 0x0072CE
+                                            text_font: font_mdi_24
+                                        - label:
+                                            id: home_therm_current_temp_value
+                                            text: "-.-°C"
+                                            text_color: 0x0F2547
+                                            text_font: font_value_big
+
+                            - obj:
                                 id: home_therm_setpoint_column
                                 width: SIZE_CONTENT
                                 height: SIZE_CONTENT
@@ -417,8 +471,3 @@ obj:
                                                   text_color: 0x1E293B
                                                   text_font: font_mdi_30
                                                   align: CENTER
-
-                      - label:
-                          id: home_therm_current_temp_value
-                          text: "-.-°C"
-                          hidden: true

--- a/src/openamber/ui/page_thermostat.yaml
+++ b/src/openamber/ui/page_thermostat.yaml
@@ -335,15 +335,12 @@ obj:
                                       id: home_therm_current_temp_card
                                       width: SIZE_CONTENT
                                       height: 58
-                                      bg_color: 0xFFFFFF
-                                      bg_opa: 100%
-                                      radius: 12
-                                      border_width: 1
-                                      border_color: 0xCBD5E1
-                                      border_opa: 100%
+                                      bg_opa: 0%
+                                      border_width: 0
+                                      border_opa: 0%
                                       pad_left: 14
                                       pad_right: 14
-                                      pad_top: 0
+                                      pad_top: 10
                                       pad_bottom: 0
                                       scrollbar_mode: "OFF"
                                       scrollable: false
@@ -364,6 +361,7 @@ obj:
                                             text: "-.-°C"
                                             text_color: 0x0F2547
                                             text_font: font_value_big
+                                            align: CENTER
 
                             - obj:
                                 id: home_therm_setpoint_column


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible room-temperature column to the compact thermostat display, including a thermometer icon and current temperature.

- **Bug Fixes**
  - Updated thermostat navigation to refresh the appropriate settings interface when selected.
  - Removed an obsolete hidden temperature display element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->