### PR TITLE
Add ethernet configuration to Waveshare P4 config

### DIFF
--- a/src/openamber-waveshare-p4.yaml
+++ b/src/openamber-waveshare-p4.yaml
@@ -6,8 +6,22 @@ packages:
  - !include openamber/ui/display_globals.yaml
  - !include openamber/ui/bindings/ui_bindings_package.yaml
  
+network:
+  priority:
+    - ethernet
+    - wifi
+
 wifi:
   use_psram: true
+
+ethernet:
+  type: W5500
+  clk_pin: 5
+  mosi_pin: 3
+  miso_pin: 2
+  cs_pin: 4
+  interrupt_pin: 29
+  reset_pin: 28
 
 esp32_ble_tracker:
 
@@ -166,7 +180,7 @@ sensor:
 # TODO: No default wiring determined yet for this sensor.
   - platform: pulse_counter
     pin:
-      number: GPIO2
+      number: GPIO6
     name: Pulse meter
     id: water_flow_rate
     device_class: volume_flow_rate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethernet support with priority over Wi-Fi.
  * Configured W5500 Ethernet pin settings.

* **Bug Fixes**
  * Updated the pulse counter input to use the correct GPIO6 connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->