### PR TITLE
Add Tui/Tuo sensor calibration offsets

### DIFF
--- a/src/openamber/common/numbers.yaml
+++ b/src/openamber/common/numbers.yaml
@@ -35,6 +35,30 @@
   optimistic: true
 
 - platform: template
+  name: "CV-retourtemperatuur (Tui) offset"
+  id: tui_offset
+  unit_of_measurement: °C
+  device_class: temperature
+  min_value: -5
+  max_value: 5
+  step: 0.1
+  initial_value: 0
+  restore_value: true
+  optimistic: true
+
+- platform: template
+  name: "CV-aanvoertemperatuur (Tuo) offset"
+  id: tuo_offset
+  unit_of_measurement: °C
+  device_class: temperature
+  min_value: -5
+  max_value: 5
+  step: 0.1
+  initial_value: 0
+  restore_value: true
+  optimistic: true
+
+- platform: template
   name: "Vorstbescherming 1e trap buiten temperatuur(Ta)"
   id: frost_protection_stage_1_temp_ta
   optimistic: true

--- a/src/openamber/common/sensors.yaml
+++ b/src/openamber/common/sensors.yaml
@@ -616,6 +616,7 @@
   filters:
     - offset: -3000
     - multiply: 0.01
+    - lambda: return x + id(tuo_offset).state;
   on_value: 
     then:
       - component.update: heat_exchanger_delta_t
@@ -636,6 +637,7 @@
   filters:
     - offset: -3000
     - multiply: 0.01
+    - lambda: return x + id(tui_offset).state;
   on_raw_value: 
     then:
       - number.set: 

--- a/src/openamber/ui/bindings/number_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/number_ui_bindings.yaml
@@ -32,6 +32,24 @@
             format: "%.1f°C"
             args: ['x']
 
+- id: !extend tui_offset
+  on_value:
+    then:
+      - lvgl.label.update:
+          id: set_tui_offset_val
+          text:
+            format: "%.1f°C"
+            args: ['x']
+
+- id: !extend tuo_offset
+  on_value:
+    then:
+      - lvgl.label.update:
+          id: set_tuo_offset_val
+          text:
+            format: "%.1f°C"
+            args: ['x']
+
 - id: !extend flow_sensor_calibration
   on_value:
     then:

--- a/src/openamber/ui/bindings/script_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/script_ui_bindings.yaml
@@ -361,6 +361,7 @@
           - lvgl.widget.hide: { id: panel_general_page_sensor_kalibratie }
           - lvgl.widget.hide: { id: panel_general_page_hardware }
           - lvgl.widget.hide: { id: panel_general_page_analytics }
+          - lvgl.widget.hide: { id: sensor_calibration_pager }
           - lvgl.widget.update: { id: general_stab_systeem, bg_color: 0x1F3B68 }
           - lvgl.label.update: { id: general_stab_systeem_lbl, text_color: 0xFFFFFF }
           - lvgl.widget.update: { id: general_stab_analytics, bg_color: 0xCBD5E1 }
@@ -382,6 +383,7 @@
                 - lvgl.widget.hide: { id: panel_general_page_sensor_kalibratie }
                 - lvgl.widget.hide: { id: panel_general_page_hardware }
                 - lvgl.widget.hide: { id: panel_general_page_analytics }
+                - lvgl.widget.hide: { id: sensor_calibration_pager }
                 - lvgl.widget.update: { id: general_stab_systeem, bg_color: 0xCBD5E1 }
                 - lvgl.label.update: { id: general_stab_systeem_lbl, text_color: 0x4B5563 }
                 - lvgl.widget.update: { id: general_stab_analytics, bg_color: 0xCBD5E1 }
@@ -426,6 +428,7 @@
                             - lvgl.widget.hide: { id: panel_general_page_sensor_kalibratie }
                             - lvgl.widget.show: { id: panel_general_page_hardware }
                             - lvgl.widget.hide: { id: panel_general_page_analytics }
+                            - lvgl.widget.hide: { id: sensor_calibration_pager }
                             - lvgl.widget.update: { id: general_stab_systeem, bg_color: 0xCBD5E1 }
                             - lvgl.label.update: { id: general_stab_systeem_lbl, text_color: 0x4B5563 }
                             - lvgl.widget.update: { id: general_stab_analytics, bg_color: 0xCBD5E1 }
@@ -443,6 +446,7 @@
                             - lvgl.widget.hide: { id: panel_general_page_sensor_kalibratie }
                             - lvgl.widget.hide: { id: panel_general_page_hardware }
                             - lvgl.widget.show: { id: panel_general_page_analytics }
+                            - lvgl.widget.hide: { id: sensor_calibration_pager }
                             - lvgl.widget.update: { id: general_stab_systeem, bg_color: 0xCBD5E1 }
                             - lvgl.label.update: { id: general_stab_systeem_lbl, text_color: 0x4B5563 }
                             - lvgl.widget.update: { id: general_stab_analytics, bg_color: 0x1F3B68 }

--- a/src/openamber/ui/bindings/script_ui_bindings.yaml
+++ b/src/openamber/ui/bindings/script_ui_bindings.yaml
@@ -109,6 +109,7 @@
   parameters:
     tab_index: int
   then:
+    - lvgl.widget.hide: { id: sensor_calibration_pager }
     - if:
         condition:
           lambda: 'return tab_index == 0;'
@@ -399,6 +400,7 @@
                       - lvgl.widget.hide: { id: panel_general_page_systeem }
                       - lvgl.widget.hide: { id: panel_general_page_noodbedrijf }
                       - lvgl.widget.show: { id: panel_general_page_sensor_kalibratie }
+                      - lvgl.widget.show: { id: sensor_calibration_pager }
                       - lvgl.widget.hide: { id: panel_general_page_hardware }
                       - lvgl.widget.hide: { id: panel_general_page_analytics }
                       - lvgl.widget.update: { id: general_stab_systeem, bg_color: 0xCBD5E1 }
@@ -411,6 +413,9 @@
                       - lvgl.label.update: { id: general_stab_sensor_kalibratie_lbl, text_color: 0xFFFFFF }
                       - lvgl.widget.update: { id: general_stab_hardware, bg_color: 0xCBD5E1 }
                       - lvgl.label.update: { id: general_stab_hardware_lbl, text_color: 0x4B5563 }
+                      - script.execute:
+                          id: sensor_calibration_select_page
+                          page: 1
                     else:
                       - if:
                           condition:
@@ -449,6 +454,33 @@
                             - lvgl.widget.update: { id: general_stab_hardware, bg_color: 0xCBD5E1 }
                             - lvgl.label.update: { id: general_stab_hardware_lbl, text_color: 0x4B5563 }
     - script.execute: update_emergency_mode_ui
+
+- id: sensor_calibration_select_page
+  mode: restart
+  parameters:
+    page: int
+  then:
+    - if:
+        condition:
+          lambda: 'return page == 1;'
+        then:
+          - lvgl.widget.show: { id: sensor_calibration_page_1_row_tr }
+          - lvgl.widget.show: { id: sensor_calibration_page_1_row_tw }
+          - lvgl.widget.show: { id: sensor_calibration_page_1_row_tc }
+          - lvgl.widget.hide: { id: sensor_calibration_page_1_row_tui }
+          - lvgl.widget.hide: { id: sensor_calibration_page_2_row_tuo }
+          - lvgl.widget.update: { id: sensor_calibration_page_1_button, bg_color: 0x1F3B68 }
+          - lvgl.widget.update: { id: sensor_calibration_page_2_button, bg_color: 0xCBD5E1 }
+          - lvgl.label.update: { id: sensor_calibration_page_indicator, text: "Pagina 1 / 2" }
+        else:
+          - lvgl.widget.hide: { id: sensor_calibration_page_1_row_tr }
+          - lvgl.widget.hide: { id: sensor_calibration_page_1_row_tw }
+          - lvgl.widget.hide: { id: sensor_calibration_page_1_row_tc }
+          - lvgl.widget.show: { id: sensor_calibration_page_1_row_tui }
+          - lvgl.widget.show: { id: sensor_calibration_page_2_row_tuo }
+          - lvgl.widget.update: { id: sensor_calibration_page_1_button, bg_color: 0xCBD5E1 }
+          - lvgl.widget.update: { id: sensor_calibration_page_2_button, bg_color: 0x1F3B68 }
+          - lvgl.label.update: { id: sensor_calibration_page_indicator, text: "Pagina 2 / 2" }
 
 - id: update_flow_sensor_calibration_ui
   mode: restart

--- a/src/openamber/ui/fonts.yaml
+++ b/src/openamber/ui/fonts.yaml
@@ -52,6 +52,8 @@
         - "\U000F0026"  # mdi-alert (legionella)
         - "\U000F0045"  # mdi-arrow-down (flow)
         - "\U000F005D"  # mdi-arrow-up (flow)
+        - "\U000F0141"  # mdi-chevron-left (pagination)
+        - "\U000F0142"  # mdi-chevron-right (pagination)
 
 - file: "openamber/ui/fonts/Inter_28pt-SemiBold.ttf"
   #weight: 500

--- a/src/openamber/ui/page_settings.yaml
+++ b/src/openamber/ui/page_settings.yaml
@@ -54,6 +54,60 @@ obj:
               scrollable: false
               widgets:
                 - !include settings/page_settings_tab_general.yaml
+                - obj:
+                    id: sensor_calibration_pager
+                    hidden: true
+                    width: 100%
+                    height: 44
+                    align: BOTTOM_MID
+                    y: -4
+                    bg_opa: 0%
+                    border_opa: 0%
+                    pad_all: 0
+                    layout:
+                      type: FLEX
+                      flex_flow: ROW
+                      flex_align_main: CENTER
+                      flex_align_cross: CENTER
+                      pad_column: 8
+                    widgets:
+                      - obj:
+                          id: sensor_calibration_page_1_button
+                          width: 40
+                          height: 36
+                          bg_color: 0x1F3B68
+                          bg_opa: 100%
+                          radius: 8
+                          border_opa: 0%
+                          scrollbar_mode: "OFF"
+                          scrollable: false
+                          on_click:
+                            - script.execute:
+                                id: sensor_calibration_select_page
+                                page: 1
+                          widgets:
+                            - label: { text: "\U000F0141", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+                      - label:
+                          id: sensor_calibration_page_indicator
+                          text: "Pagina 1 / 2"
+                          text_color: 0x4B5563
+                          text_font: font_text_20
+                      - obj:
+                          id: sensor_calibration_page_2_button
+                          width: 40
+                          height: 36
+                          bg_color: 0xCBD5E1
+                          bg_opa: 100%
+                          radius: 8
+                          border_opa: 0%
+                          scrollbar_mode: "OFF"
+                          scrollable: false
+                          on_click:
+                            - script.execute:
+                                id: sensor_calibration_select_page
+                                page: 2
+                          widgets:
+                            - label: { text: "\U000F0142", text_color: 0x4B5563, text_font: font_mdi_24, align: CENTER }
                 - !include settings/page_settings_tab_advanced.yaml
                 - !include settings/page_settings_tab_pump.yaml
                 - !include settings/page_settings_tab_heating.yaml

--- a/src/openamber/ui/settings/page_settings_tab_general.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_general.yaml
@@ -251,7 +251,8 @@ obj:
         id: panel_general_page_sensor_kalibratie
         hidden: true
         width: 100%
-        height: SIZE_CONTENT
+        height: 0
+        flex_grow: 1
         bg_opa: 0%
         border_opa: 0%
         pad_all: 0
@@ -265,6 +266,7 @@ obj:
           pad_row: 6
         widgets:
           - obj:
+              id: sensor_calibration_page_1_row_tr
               width: 100%
               height: SIZE_CONTENT
               bg_opa: 0%
@@ -311,6 +313,7 @@ obj:
                             - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
 
           - obj:
+              id: sensor_calibration_page_1_row_tw
               width: 100%
               height: SIZE_CONTENT
               bg_opa: 0%
@@ -357,6 +360,7 @@ obj:
                             - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
 
           - obj:
+              id: sensor_calibration_page_1_row_tc
               width: 100%
               height: SIZE_CONTENT
               bg_opa: 0%
@@ -403,6 +407,7 @@ obj:
                             - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
 
           - obj:
+              id: sensor_calibration_page_1_row_tui
               width: 100%
               height: SIZE_CONTENT
               bg_opa: 0%
@@ -449,6 +454,7 @@ obj:
                             - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
 
           - obj:
+              id: sensor_calibration_page_2_row_tuo
               width: 100%
               height: SIZE_CONTENT
               bg_opa: 0%

--- a/src/openamber/ui/settings/page_settings_tab_general.yaml
+++ b/src/openamber/ui/settings/page_settings_tab_general.yaml
@@ -1,4 +1,4 @@
-﻿# Panel: Algemeen
+# Panel: Algemeen
 # ------------------------------------------------------------
 obj:
   id: panel_general
@@ -399,6 +399,98 @@ obj:
                           scrollable: false
                           on_click:
                             - number.increment: tc_offset
+                          widgets:
+                            - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+
+          - obj:
+              width: 100%
+              height: SIZE_CONTENT
+              bg_opa: 0%
+              border_opa: 0%
+              pad_all: 6
+              widgets:
+                - label: { text: "CV-retourtemperatuur (Tui) offset", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+                - label: { text: "Correctie voor CV-retourtemperatuurmeting (Tui)", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+                - obj:
+                    width: SIZE_CONTENT
+                    height: SIZE_CONTENT
+                    align: TOP_RIGHT
+                    bg_opa: 0%
+                    border_opa: 0%
+                    pad_all: 0
+                    layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
+                    widgets:
+                      - obj:
+                          width: 40
+                          height: 40
+                          bg_color: 0x1F3B68
+                          bg_opa: 100%
+                          radius: 10
+                          border_opa: 0%
+                          scrollbar_mode: "OFF"
+                          scrollable: false
+                          on_click:
+                            - number.decrement: tui_offset
+                          widgets:
+                            - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+                      - label: { id: set_tui_offset_val, text: "0.0°C", text_color: 0x1F2933, text_font: font_text_24 }
+                      - obj:
+                          width: 40
+                          height: 40
+                          bg_color: 0x1F3B68
+                          bg_opa: 100%
+                          radius: 10
+                          border_opa: 0%
+                          scrollbar_mode: "OFF"
+                          scrollable: false
+                          on_click:
+                            - number.increment: tui_offset
+                          widgets:
+                            - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+
+          - obj:
+              width: 100%
+              height: SIZE_CONTENT
+              bg_opa: 0%
+              border_opa: 0%
+              pad_all: 6
+              widgets:
+                - label: { text: "CV-aanvoertemperatuur (Tuo) offset", text_color: 0x1F2933, text_font: font_text_24, align: TOP_LEFT }
+                - label: { text: "Correctie voor CV-aanvoertemperatuurmeting (Tuo)", text_color: 0x6B7280, text_font: font_text_20, align: TOP_LEFT, y: 38 }
+                - obj:
+                    width: SIZE_CONTENT
+                    height: SIZE_CONTENT
+                    align: TOP_RIGHT
+                    bg_opa: 0%
+                    border_opa: 0%
+                    pad_all: 0
+                    layout: { type: FLEX, flex_flow: ROW, flex_align_cross: CENTER, pad_column: 8 }
+                    widgets:
+                      - obj:
+                          width: 40
+                          height: 40
+                          bg_color: 0x1F3B68
+                          bg_opa: 100%
+                          radius: 10
+                          border_opa: 0%
+                          scrollbar_mode: "OFF"
+                          scrollable: false
+                          on_click:
+                            - number.decrement: tuo_offset
+                          widgets:
+                            - label: { text: "\U000F0374", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
+                      - label: { id: set_tuo_offset_val, text: "0.0°C", text_color: 0x1F2933, text_font: font_text_24 }
+                      - obj:
+                          width: 40
+                          height: 40
+                          bg_color: 0x1F3B68
+                          bg_opa: 100%
+                          radius: 10
+                          border_opa: 0%
+                          scrollbar_mode: "OFF"
+                          scrollable: false
+                          on_click:
+                            - number.increment: tuo_offset
                           widgets:
                             - label: { text: "\U000F0415", text_color: 0xFFFFFF, text_font: font_mdi_24, align: CENTER }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adjustable calibration offsets for return and supply temperatures, configurable from −5 to 5 °C in 0.1 °C steps.
  * Added a two-page sensor-calibration section in General settings.
  * Calibration values now appear in the interface and update immediately when changed.
  * Temperature readings reflect the configured calibration offsets.
* **UI Improvements**
  * Added navigation controls and page indicators for sensor calibration settings.
  * Calibration controls now include dedicated increment and decrement buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->